### PR TITLE
fix(LayersService): disconnect resizeObserver when the service is detached

### DIFF
--- a/src/services/LayersService.ts
+++ b/src/services/LayersService.ts
@@ -61,9 +61,10 @@ export class Layers extends Emitter {
       });
 
       this.attached = false;
-      this.handleRootResize.cancel();
-      this.resizeObserver.disconnect();
     }
+
+    this.handleRootResize.cancel();
+    this.resizeObserver.disconnect();
 
     if (full) {
       this.$root = undefined;


### PR DESCRIPTION
This will fix the clientWidth error in the console.