### PR TITLE
fix(Camera): fix block event propagation

### DIFF
--- a/src/components/canvas/blocks/controllers/BlockController.ts
+++ b/src/components/canvas/blocks/controllers/BlockController.ts
@@ -33,17 +33,19 @@ export class BlockController<T extends TBlock = TBlock, Props extends TBlockProp
       },
 
       mousedown(event: MouseEvent) {
-        event.stopPropagation();
         const blockState = selectBlockById(block.context.graph, block.props.id);
-        const blocksListState = this.context.graph.rootStore.blocksList;
-        const selectedBlocksStates = getSelectedBlocks(blockState, blocksListState);
-        const selectedBlocksComponents = selectedBlocksStates.map((block) => block.getViewComponent());
         const allowChangeBlockGeometry = isAllowChangeBlockGeometry(
           block.getConfigFlag("canChangeBlockGeometry") as ECanChangeBlockGeometry,
           blockState.selected
         );
 
         if (!allowChangeBlockGeometry) return;
+
+        event.stopPropagation();
+
+        const blocksListState = this.context.graph.rootStore.blocksList;
+        const selectedBlocksStates = getSelectedBlocks(blockState, blocksListState);
+        const selectedBlocksComponents = selectedBlocksStates.map((block) => block.getViewComponent());
 
         dragListener(block.context.ownerDocument)
           .on(EVENTS.DRAG_START, (_event: MouseEvent) => {


### PR DESCRIPTION
Stop event propagation on block only if it geometry can be changed, so we can drag camera when clicking on block.