### PR TITLE
fix: improve anchors props type

### DIFF
--- a/src/components/canvas/anchors/index.ts
+++ b/src/components/canvas/anchors/index.ts
@@ -28,7 +28,7 @@ type TAnchorState = {
   selected: boolean;
 };
 
-export class Anchor extends GraphComponent<TAnchorProps, TAnchorState> {
+export class Anchor<T extends TAnchorProps = TAnchorProps> extends GraphComponent<T, TAnchorState> {
   public readonly cursor = "pointer";
 
   public get zIndex() {
@@ -38,7 +38,7 @@ export class Anchor extends GraphComponent<TAnchorProps, TAnchorState> {
 
   public declare state: TAnchorState;
 
-  public declare props: TAnchorProps;
+  public declare props: T;
 
   public declare context: TGraphLayerContext;
 
@@ -59,7 +59,7 @@ export class Anchor extends GraphComponent<TAnchorProps, TAnchorState> {
     }
   );
 
-  constructor(props: TAnchorProps, parent: GraphLayer) {
+  constructor(props: T, parent: GraphLayer) {
     super(props, parent);
     this.state = { size: props.size, raised: false, selected: false };
 


### PR DESCRIPTION
When creating an anchor, you can add custom fields to the props.
But ts will start swearing because of the discrepancy between the types, and you have to "cast" it.
In this PR, it is proposed to shift the type matching problem onto the user.