### PR TITLE
fix: delayed anchor render on html layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ export function GraphEditor() {
 
 - [Pulic API](docs/public_api.md)
 - [Graph Events](docs/events.md)
-- [Editing](docs/editing.md)
+- [Layers](docs/layers.md)
+- [Groups](docs/groups.md)

--- a/src/react-component/Anchor.tsx
+++ b/src/react-component/Anchor.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useMemo } from "react";
+import React, { useMemo } from "react";
 
 import { TAnchor } from "../components/canvas/anchors";
 import { Graph } from "../graph";
@@ -22,9 +22,10 @@ export function GraphBlockAnchor({
   className?: string;
   children?: React.ReactNode | ((anchorState: AnchorState) => React.ReactNode);
 }) {
+  const anchorContainerRef = React.useRef<HTMLDivElement>(null);
   const anchorState = useBlockAnchorState(graph, anchor);
 
-  const coords = useBlockAnchorPosition(anchorState);
+  useBlockAnchorPosition(anchorState, anchorContainerRef);
 
   const selected = useSignal(anchorState?.$selected);
 
@@ -38,15 +39,7 @@ export function GraphBlockAnchor({
   if (!anchorState) return null;
 
   return (
-    <div
-      style={
-        {
-          "--graph-block-anchor-x": `${coords.x}px`,
-          "--graph-block-anchor-y": `${coords.y}px`,
-        } as CSSProperties
-      }
-      className={classNames}
-    >
+    <div ref={anchorContainerRef} className={classNames}>
       {render(anchorState)}
     </div>
   );


### PR DESCRIPTION
If you can dynamically resize blocks on the graph, the position of the anchors on the html layer is drawn with a delay.
In this PR I removed the delay and edited the css variables directly, bypassing the asynchronous setState.