### PR TITLE
feat(NewBlockLayer, ConnectionLayer): added validation and duplication of blocks by a group

### DIFF
--- a/docs/system/public_api.md
+++ b/docs/system/public_api.md
@@ -37,7 +37,7 @@ List of methods in your disposition:
 
   public unsetSelection(): void;
 
-  public addBlock(block: Omit<TBlock, "id"> & { id?: TBlockId }): TBlockId;
+  public addBlock(block: Omit<TBlock, "id"> & { id?: TBlockId }, selectionOptions?: { selected?: boolean; strategy?: ESelectionStrategy }): TBlockId;
 
   public addConnection(connection: TConnection): TConnectionId
 
@@ -63,3 +63,4 @@ const update = useCallback(() => {
     blocks: [{...block, name: 'Updated Name'}],
   });
 })
+```

--- a/src/api/PublicGraphApi.ts
+++ b/src/api/PublicGraphApi.ts
@@ -117,9 +117,19 @@ export class PublicGraphApi {
     blockStore?.updateBlock(block);
   }
 
-  public addBlock(block: Omit<TBlock, "id"> & { id?: TBlockId }): TBlockId {
+  public addBlock(
+    block: Omit<TBlock, "id"> & { id?: TBlockId },
+    selectionOptions?: {
+      selected?: boolean;
+      strategy?: ESelectionStrategy;
+    }
+  ): TBlockId {
     const newBlockId = this.graph.rootStore.blocksList.addBlock(block);
-    this.graph.rootStore.blocksList.updateBlocksSelection([newBlockId], true);
+    this.graph.rootStore.blocksList.updateBlocksSelection(
+      [newBlockId],
+      selectionOptions?.selected !== undefined ? selectionOptions.selected : true,
+      selectionOptions?.strategy
+    );
     return newBlockId;
   }
 

--- a/src/api/PublicGraphApi.ts
+++ b/src/api/PublicGraphApi.ts
@@ -125,11 +125,15 @@ export class PublicGraphApi {
     }
   ): TBlockId {
     const newBlockId = this.graph.rootStore.blocksList.addBlock(block);
-    this.graph.rootStore.blocksList.updateBlocksSelection(
-      [newBlockId],
-      selectionOptions?.selected !== undefined ? selectionOptions.selected : true,
-      selectionOptions?.strategy
-    );
+
+    if (selectionOptions !== undefined) {
+      this.graph.rootStore.blocksList.updateBlocksSelection(
+        [newBlockId],
+        selectionOptions.selected !== undefined ? selectionOptions.selected : true,
+        selectionOptions.strategy
+      );
+    }
+
     return newBlockId;
   }
 

--- a/src/components/canvas/layers/connectionLayer/ConnectionLayer.md
+++ b/src/components/canvas/layers/connectionLayer/ConnectionLayer.md
@@ -1,6 +1,6 @@
 # ConnectionLayer
 
-`ConnectionLayer` lets you create connections between blocks and anchors in your graph. It enables creating new connections through an intuitive drag and drop interface, handles the drawing of connection lines, and manages all related events.
+`ConnectionLayer` manages the creation and visualization of connections between blocks and anchors in your graph. It provides an interactive drag and drop interface, customizable connection appearance, automatic selection handling, and a comprehensive event system for the entire connection lifecycle.
 
 ## Basic Usage
 
@@ -35,6 +35,14 @@ graph.addLayer(ConnectionLayer, {
       style: { color: "blue", dash: [5, 5] }
     };
   },
+  isConnectionAllowed: (sourceComponent) => {
+    // Example: Only allow connections from anchor components
+    const isSourceAnchor = sourceComponent instanceof AnchorState;
+    return isSourceAnchor;
+    
+    // Or validate based on component properties
+    // return sourceComponent.someProperty === true;
+  },
   // ... other props
 })
 ```
@@ -48,6 +56,7 @@ type ConnectionLayerProps = LayerProps & {
   createIcon?: TIcon;
   point?: TIcon;
   drawLine?: DrawLineFunction;
+  isConnectionAllowed?: (sourceComponent: BlockState | AnchorState) => boolean;
 };
 
 type TIcon = {
@@ -64,6 +73,7 @@ type TIcon = {
 - **createIcon**: The icon shown when creating a connection
 - **point**: The icon shown at the end of the connection
 - **drawLine**: Function that defines how to draw the connection line
+- **isConnectionAllowed**: Function that validates if a connection can be created from a source component
 
 ## Methods
 
@@ -76,49 +86,55 @@ The layer provides these events:
 
 ### connection-create-start
 
-Fired when a user starts creating a connection.
+Fired when a user initiates a connection from a block or anchor. This happens when dragging starts from a block (with Shift key) or an anchor. Preventing this event will prevent the selection of the source component.
 
 ```typescript
 graph.on("connection-create-start", (event) => {
   console.log('Creating connection from block', event.detail.blockId);
+  
+  // If you prevent this event, the source component won't be selected
+  // event.preventDefault();
 })
 ```
 
 ### connection-create-hover
 
-Fired when hovering over a potential target while creating a connection.
+Fired when the dragged connection endpoint hovers over a potential target block or anchor. Preventing this event will prevent the selection of the target component.
 
 ```typescript
 graph.on("connection-create-hover", (event) => {
-  // Prevent connection to this target
-  event.preventDefault();
+  // If you prevent this event, the target component won't be selected
+  // event.preventDefault();
 })
 ```
 
 ### connection-created
 
-Fired when a connection is successfully created.
+Fired when a connection is successfully created between two elements. By default, this adds the connection to the connectionsList in the store. Preventing this event will prevent the connection from being added to the store.
 
 ```typescript
 graph.on("connection-created", (event) => {
   // The connection is added to connectionsList by default
-  // You can prevent this:
-  event.preventDefault();
+  // If you prevent this event, the connection won't be added to the store
+  // event.preventDefault();
 })
 ```
 
 ### connection-create-drop
 
-Fired when the user drops the connection endpoint, whether or not a connection was created.
+Fired when the user releases the mouse button to complete the connection process. This event fires regardless of whether a valid connection was established. Can be used for cleanup or to handle custom connection drop behavior.
 
 ```typescript
 graph.on("connection-create-drop", (event) => {
   console.log('Connection dropped at', event.detail.point);
+  
+  // This event is useful for cleanup or custom drop handling
 })
 ```
 
 ## How Connections Work
 
 - Hold Shift and drag from one block to another to create a block-to-block connection
-- Drag from one anchor to another to create an anchor-to-anchor connection
+- Drag from one anchor to another to create an anchor-to-anchor connection (must be on different blocks)
 - Elements are automatically selected during connection creation
+- Optional connection validation through the isConnectionAllowed prop

--- a/src/components/canvas/layers/connectionLayer/ConnectionLayer.md
+++ b/src/components/canvas/layers/connectionLayer/ConnectionLayer.md
@@ -1,6 +1,6 @@
 # ConnectionLayer
 
-`ConnectionLayer` manages the creation and visualization of connections between blocks and anchors in your graph. It provides an interactive drag and drop interface, customizable connection appearance, automatic selection handling, and a comprehensive event system for the entire connection lifecycle.
+`ConnectionLayer` manages the creation process of connections between blocks and anchors in your graph. It provides an interactive drag and drop interface for creating new connections, temporary visualization during connection creation, automatic selection handling, and a comprehensive event system for the connection creation lifecycle.
 
 ## Basic Usage
 

--- a/src/components/canvas/layers/connectionLayer/ConnectionLayer.ts
+++ b/src/components/canvas/layers/connectionLayer/ConnectionLayer.ts
@@ -95,14 +95,14 @@ declare module "../../../../graphEvents" {
 }
 
 /**
- * ConnectionLayer manages the creation and visualization of connections
- * between blocks and anchors in the graph.
+ * ConnectionLayer manages the creation process of connections between blocks and anchors in the graph.
+ * It handles the temporary visualization during connection creation but does not render existing connections.
  *
  * Features:
  * - Interactive connection creation through drag and drop
- * - Customizable connection appearance with configurable icons and line styles
+ * - Temporary visualization during connection creation with configurable icons and line styles
  * - Automatic selection handling of source and target elements
- * - Comprehensive event system for the entire connection lifecycle
+ * - Comprehensive event system for the connection creation lifecycle
  * - Optional connection validation through isConnectionAllowed prop
  *
  * Connection types:

--- a/src/components/canvas/layers/newBlockLayer/NewBlockLayer.md
+++ b/src/components/canvas/layers/newBlockLayer/NewBlockLayer.md
@@ -2,6 +2,10 @@
 
 `NewBlockLayer` enables block duplication through an intuitive Alt+drag interaction. When a user holds the Alt key and drags an existing block, this layer creates a ghost representation that follows the cursor, and upon release, a new block is created based on the original.
 
+The layer supports two duplication modes:
+1. **Single block duplication**: When Alt+dragging a non-selected block, only that block is duplicated
+2. **Multiple block duplication**: When Alt+dragging a selected block, all selected blocks are duplicated together
+
 ## Basic Usage
 
 ```typescript
@@ -20,6 +24,31 @@ const graph = useGraph({
 });
 ```
 
+## Configuration Options
+
+- **ghostBackground**: Background color for displaying the block shadow. By default, the block border color from the theme is used.
+- **isDuplicateAllowed**: Function to check if block duplication is allowed. Takes a block as a parameter and returns a boolean value.
+
+Example with duplication validation:
+
+```typescript
+const graph = useGraph();
+
+const newBlockLayer = graph.addLayer(NewBlockLayer, {
+  // Custom ghost background color
+  ghostBackground: 'rgba(0, 100, 255, 0.3)',
+  
+  // Only allow duplication of blocks that meet certain criteria
+  isDuplicateAllowed: (block) => {
+    // For example, prevent duplication of locked blocks
+    return !block.connectedState.isLocked;
+    
+    // Or prevent duplication of blocks with specific types
+    // return block.connectedState.type !== 'restricted-block';
+  }
+});
+```
+
 ## Methods
 
 - **enable()**: Enables block duplication functionality
@@ -32,28 +61,32 @@ The layer provides these events:
 
 ### block-add-start-from-shadow
 
-Fired when a user starts duplicating a block (Alt+mousedown).
+Fired when a user starts duplicating blocks (Alt+mousedown). Provides an array of blocks that will be duplicated.
 
 ```typescript
 graph.on("block-add-start-from-shadow", (event) => {
-  console.log('Duplicating block', event.detail.sourceBlockId);
+  // event.detail.blocks - array of blocks that will be duplicated
+  console.log('Duplicating blocks:', event.detail.blocks.length);
 })
 ```
 
 ### block-added-from-shadow
 
-Fired when a block duplication is completed.
+Fired when block duplication is completed. Provides an array of items, each containing a block and its target coordinate, as well as the delta coordinates between the start and end positions of the mouse.
 
 ```typescript
 graph.on("block-added-from-shadow", (event) => {
-  console.log('Block duplicated from', event.detail.sourceBlockId);
-  console.log('At coordinates', event.detail.coord);
+  // event.detail.items - array of objects with block and coord properties
+  // event.detail.delta - object with x and y properties representing the movement distance
   
-  // Create the actual block based on the source block
-  const newBlock = createBlockFromSource(
-    event.detail.sourceBlockId, 
-    event.detail.coord
-  );
+  // Create the actual blocks based on the source blocks
+  event.detail.items.forEach((item) => {
+    const { block, coord } = item;
+    createBlockFromSource(block, coord);
+  });
+  
+  // You can also use the delta information
+  console.log(`Blocks were moved ${event.detail.delta.x}px horizontally and ${event.detail.delta.y}px vertically`);
 })
 ```
 
@@ -61,5 +94,17 @@ graph.on("block-added-from-shadow", (event) => {
 
 - Hold Alt and drag from an existing block to create a duplicate
 - A semi-transparent ghost of the block follows your cursor during dragging
-- When you release the mouse button, a new block is created at that position
+- When you release the mouse button, new blocks are created:
+  - If you started dragging from a non-selected block, only that block is duplicated
+  - If you started dragging from a selected block, all selected blocks are duplicated, maintaining their relative positions
 - The actual block creation must be implemented by handling the `block-added-from-shadow` event
+
+## Duplication Validation
+
+When the `isDuplicateAllowed` function is provided:
+
+1. The function is called immediately when a user attempts to start a duplication (Alt+mousedown)
+2. If the function returns `false` for the clicked block, the duplication process is canceled
+3. For multiple block duplication (when a selected block is clicked), each selected block is checked:
+   - Only blocks that pass the validation will be duplicated
+   - If no blocks pass validation, the duplication process is canceled

--- a/src/components/canvas/layers/newBlockLayer/NewBlockLayer.ts
+++ b/src/components/canvas/layers/newBlockLayer/NewBlockLayer.ts
@@ -6,36 +6,60 @@ import { dragListener } from "../../../../utils/functions/dragListener";
 import { render } from "../../../../utils/renderers/render";
 import { EVENTS } from "../../../../utils/types/events";
 import { TPoint } from "../../../../utils/types/shapes";
+import { ESelectionStrategy } from "../../../../utils/types/types";
 import { Block } from "../../../canvas/blocks/Block";
 
+/**
+ * Events emitted by the NewBlockLayer
+ */
 declare module "../../../../graphEvents" {
   interface GraphEventsDefinitions {
-    "block-add-start-from-shadow": (event: CustomEvent<{ block: Block }>) => void;
-    "block-added-from-shadow": (event: CustomEvent<{ block: Block; coord: TPoint }>) => void;
+    /**
+     * Fired when block duplication starts
+     */
+    "block-add-start-from-shadow": (event: CustomEvent<{ blocks: Block[] }>) => void;
+
+    /**
+     * Fired when block duplication completes
+     */
+    "block-added-from-shadow": (
+      event: CustomEvent<{
+        items: Array<{ block: Block; coord: TPoint }>;
+        delta: TPoint;
+      }>
+    ) => void;
   }
 }
 
 export interface NewBlockLayerProps extends LayerProps {
   /**
-   * Цвет фона для отображения тени блока
-   * По умолчанию используется цвет границы блока из темы
+   * Background color for displaying the block shadow
+   * By default, the block border color from the theme is used
    */
   ghostBackground?: string;
+
+  /**
+   * Function to check if block duplication is allowed
+   * @param block The block being duplicated
+   * @returns true if duplication is allowed, false if not allowed
+   */
+  isDuplicateAllowed?: (block: Block) => boolean;
 }
 
 export class NewBlockLayer extends Layer<
   NewBlockLayerProps,
   LayerContext & { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D }
 > {
-  private copyBlock: BlockState;
-  private blockState = {
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
-  };
-
+  private copyBlocks: BlockState[] = [];
+  private initialPoint: TPoint;
+  private blockStates: Array<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }> = [];
   private enabled = true;
+  private declare eventAborter: AbortController;
 
   constructor(props: NewBlockLayerProps) {
     super({
@@ -56,9 +80,10 @@ export class NewBlockLayer extends Layer<
       graph: this.props.graph,
     });
 
+    this.eventAborter = new AbortController();
     this.performRender = this.performRender.bind(this);
-    this.context.graph.on("camera-change", this.performRender);
-    this.context.graph.on("mousedown", this.handleMouseDown, { capture: true });
+    this.context.graph.on("camera-change", this.performRender, { signal: this.eventAborter.signal });
+    this.context.graph.on("mousedown", this.handleMouseDown, { capture: true, signal: this.eventAborter.signal });
   }
 
   protected getOwnerDocument() {
@@ -69,6 +94,11 @@ export class NewBlockLayer extends Layer<
     const event = extractNativeGraphMouseEvent(nativeEvent);
     const target = nativeEvent.detail.target;
     if (event && isAltKeyEvent(event) && isBlock(target) && this.enabled) {
+      // Check if duplication is allowed for this block
+      if (this.props.isDuplicateAllowed && !this.props.isDuplicateAllowed(target)) {
+        return; // Exit if duplication is not allowed
+      }
+
       nativeEvent.preventDefault();
       nativeEvent.stopPropagation();
       dragListener(this.getOwnerDocument())
@@ -83,66 +113,249 @@ export class NewBlockLayer extends Layer<
   protected render() {
     this.resetTransform();
 
-    if (!this.blockState.width && !this.blockState.height) {
+    if (!this.blockStates.length) {
       return;
     }
 
     render(this.context.ctx, (ctx) => {
       ctx.beginPath();
       ctx.fillStyle = this.props.ghostBackground || this.context.colors.block.border;
-      ctx.fillRect(this.blockState.x, this.blockState.y, this.blockState.width, this.blockState.height);
+
+      // Draw each block ghost
+      for (const blockState of this.blockStates) {
+        ctx.fillRect(blockState.x, blockState.y, blockState.width, blockState.height);
+      }
+
       ctx.closePath();
     });
   }
 
   protected unmount(): void {
-    this.context.graph.off("camera-change", this.performRender);
-    this.context.graph.off("mousedown", this.handleMouseDown);
+    this.eventAborter.abort();
+
+    super.unmount();
   }
 
   private onStartNewBlock(event: MouseEvent, block: Block) {
-    this.context.graph.executеDefaultEventAction("block-add-start-from-shadow", { block: block }, () => {
-      this.copyBlock = block.connectedState;
+    // Check if the clicked block is selected
+    const isBlockSelected = block.connectedState.selected;
+
+    // Get the blocks to duplicate
+    let blockStates: BlockState[];
+
+    if (isBlockSelected) {
+      // If the clicked block is selected, get all selected blocks
+      const selectedBlockStates = this.context.graph.rootStore.blocksList.$selectedBlocks.value;
+
+      // If we have a validation function, filter out blocks that can't be duplicated
+      if (this.props.isDuplicateAllowed) {
+        blockStates = selectedBlockStates.filter((blockState) =>
+          this.props.isDuplicateAllowed(blockState.getViewComponent())
+        );
+
+        // If no blocks can be duplicated, exit
+        if (blockStates.length === 0) return;
+      } else {
+        blockStates = selectedBlockStates;
+      }
+    } else {
+      // If the clicked block is not selected, use only the clicked block
+      blockStates = [block.connectedState];
+    }
+
+    // Map BlockState to Block for the event
+    const blocks = isBlockSelected ? blockStates.map((blockState) => blockState.getViewComponent()) : [block];
+
+    // Use the already filtered blockStates
+    this.copyBlocks = blockStates;
+
+    // Store the initial point for calculating the offset later
+    this.initialPoint = this.context.graph.getPointInCameraSpace(event);
+
+    this.context.graph.executеDefaultEventAction("block-add-start-from-shadow", { blocks }, () => {
       const xy = getXY(this.context.graphCanvas, event);
-      this.blockState = {
-        width: this.context.constants.block.WIDTH * this.context.camera.getCameraScale(),
-        height: this.context.constants.block.HEIGHT * this.context.camera.getCameraScale(),
-        x: xy[0],
-        y: xy[1],
-      };
+      const mouseX = xy[0];
+      const mouseY = xy[1];
+
+      // Calculate the screen position of the clicked block
+      const cameraRect = this.context.camera.getCameraRect();
+      const clickedBlockX = block.connectedState.x * this.context.camera.getCameraScale() + cameraRect.x;
+      const clickedBlockY = block.connectedState.y * this.context.camera.getCameraScale() + cameraRect.y;
+
+      // Calculate the click position relative to the block's top-left corner
+      const clickOffsetX = mouseX - clickedBlockX;
+      const clickOffsetY = mouseY - clickedBlockY;
+
+      // Create ghost blocks for each block being duplicated
+      this.blockStates = this.copyBlocks.map((blockState) => {
+        // Calculate screen position for each block
+        const blockScreenX = blockState.x * this.context.camera.getCameraScale() + cameraRect.x;
+        const blockScreenY = blockState.y * this.context.camera.getCameraScale() + cameraRect.y;
+
+        // Use block's own width and height values
+        const blockWidth = blockState.width * this.context.camera.getCameraScale();
+        const blockHeight = blockState.height * this.context.camera.getCameraScale();
+
+        return {
+          width: blockWidth,
+          height: blockHeight,
+          // Position the ghost block so that the click offset is maintained
+          x: mouseX - clickOffsetX + (blockScreenX - clickedBlockX),
+          y: mouseY - clickOffsetY + (blockScreenY - clickedBlockY),
+        };
+      });
+
       this.performRender();
     });
   }
 
+  private lastMouseX: number;
+  private lastMouseY: number;
+
   private onMoveNewBlock(event: MouseEvent) {
-    if (!this.copyBlock) {
+    if (!this.copyBlocks.length) {
       return;
     }
+
     const xy = getXY(this.context.graphCanvas, event);
-    this.blockState = {
-      ...this.blockState,
-      x: xy[0],
-      y: xy[1],
-    };
+    const mouseX = xy[0];
+    const mouseY = xy[1];
+
+    // If this is the first move event, initialize the last mouse position
+    if (this.lastMouseX === undefined) {
+      this.lastMouseX = mouseX;
+      this.lastMouseY = mouseY;
+      return;
+    }
+
+    // Calculate the movement delta
+    const deltaX = mouseX - this.lastMouseX;
+    const deltaY = mouseY - this.lastMouseY;
+
+    // Update positions of all ghost blocks by applying the delta
+    this.blockStates = this.blockStates.map((blockState) => {
+      return {
+        ...blockState,
+        x: blockState.x + deltaX,
+        y: blockState.y + deltaY,
+      };
+    });
+
+    // Update the last mouse position
+    this.lastMouseX = mouseX;
+    this.lastMouseY = mouseY;
+
     this.performRender();
   }
 
   private onEndNewBlock(event: MouseEvent, point: TPoint) {
-    if (!this.copyBlock) {
+    if (!this.copyBlocks.length) {
       return;
     }
-    this.blockState = {
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-    };
+
+    // Clear the block states and reset mouse tracking
+    this.blockStates = [];
+    this.lastMouseX = undefined;
+    this.lastMouseY = undefined;
     this.performRender();
-    this.context.graph.emit("block-added-from-shadow", {
-      block: this.copyBlock.getViewComponent(),
-      coord: point,
+
+    // Calculate the offset from the initial point to the final point
+    const offsetX = point.x - this.initialPoint.x;
+    const offsetY = point.y - this.initialPoint.y;
+
+    // Collect all blocks and their new coordinates as items
+    const items = this.copyBlocks.map((blockState) => {
+      // Calculate the new position for each block based on its original position plus the offset
+      const newCoord = {
+        x: blockState.x + offsetX,
+        y: blockState.y + offsetY,
+      };
+
+      return {
+        block: blockState.getViewComponent(),
+        coord: newCoord,
+      };
     });
-    this.copyBlock = null;
+
+    // Calculate the delta between start and end positions
+    const delta = {
+      x: offsetX,
+      y: offsetY,
+    };
+
+    // Emit a single event with all items and the position delta
+    this.context.graph.executеDefaultEventAction(
+      "block-added-from-shadow",
+      {
+        items,
+        delta,
+      },
+      () => {
+        // Clear selection of old blocks before adding new ones
+        this.context.graph.api.unsetSelection();
+
+        // Map to store original block ID to new block ID mapping
+        const blockIdMap = new Map<string, string>();
+
+        // First pass: create all blocks and build the ID mapping
+        items.forEach((item) => {
+          const block = item.block.connectedState.asTBlock();
+          const blockPoint = item.coord;
+          const newBlockId = `${block.id.toString()}-added-from-shadow-${Date.now()}`;
+
+          // Store the mapping between original and new block IDs
+          blockIdMap.set(block.id.toString(), newBlockId);
+
+          this.context.graph.api.addBlock(
+            {
+              ...block,
+              id: newBlockId,
+              is: "block",
+              x: blockPoint.x,
+              y: blockPoint.y,
+            },
+            {
+              selected: true,
+              strategy: ESelectionStrategy.APPEND, // Use APPEND strategy to keep all blocks selected
+            }
+          );
+        });
+
+        // Second pass: duplicate connections between duplicated blocks
+        if (blockIdMap.size > 1) {
+          // Only process connections if we have at least 2 blocks
+          // Get all connections from the graph
+          const connections = this.context.graph.rootStore.connectionsList.$connections.value;
+
+          // Check each connection to see if it connects blocks that were duplicated
+          connections.forEach((connection) => {
+            const sourceId = connection.sourceBlockId;
+            const targetId = connection.targetBlockId;
+
+            // If both source and target blocks were duplicated, create a new connection
+            if (blockIdMap.has(sourceId.toString()) && blockIdMap.has(targetId.toString())) {
+              const newSourceId = blockIdMap.get(sourceId.toString());
+              const newTargetId = blockIdMap.get(targetId.toString());
+
+              // Create a new connection between the duplicated blocks
+              this.context.graph.api.addConnection({
+                sourceBlockId: newSourceId,
+                targetBlockId: newTargetId,
+                sourceAnchorId: connection.sourceAnchorId,
+                targetAnchorId: connection.targetAnchorId,
+                // Copy any other connection properties
+                styles: connection.$state.value.styles,
+                dashed: connection.$state.value.dashed,
+                label: connection.$state.value.label,
+              });
+            }
+          });
+        }
+      }
+    );
+
+    this.copyBlocks = [];
+    this.initialPoint = null;
   }
 
   public enable(): void {

--- a/src/react-component/hooks/useGraph.ts
+++ b/src/react-component/hooks/useGraph.ts
@@ -65,14 +65,16 @@ export function useGraph(config: HookGraphParams) {
       graph.stop();
     }),
     setViewConfiguration,
-    addLayer: <T extends Constructor<Layer> = Constructor<Layer>>(
-      layerCtor: T,
-      props: T extends Constructor<Layer<infer Props>>
-        ? Omit<Props, "root" | "camera" | "graph" | "emitter"> & { root?: Props["root"] }
-        : never
-    ): InstanceType<T> => {
-      return graph.addLayer(layerCtor, props);
-    },
+    addLayer: useFn(
+      <T extends Constructor<Layer> = Constructor<Layer>>(
+        layerCtor: T,
+        props: T extends Constructor<Layer<infer Props>>
+          ? Omit<Props, "root" | "camera" | "graph" | "emitter"> & { root?: Props["root"] }
+          : never
+      ): InstanceType<T> => {
+        return graph.addLayer(layerCtor, props);
+      }
+    ),
     setEntities: useFn(<B extends TBlock, C extends TConnection>(entities: { blocks?: B[]; connections?: C[] }) => {
       graph.setEntities(entities);
     }),

--- a/src/stories/examples/newBlockLayer/newBlockLayer.stories.tsx
+++ b/src/stories/examples/newBlockLayer/newBlockLayer.stories.tsx
@@ -34,22 +34,8 @@ const GraphApp = () => {
 
   const [enabled, setEnabled] = useState(true);
 
-  useEffect(() => {
-    graph.on("block-added-from-shadow", (event) => {
-      const block = event.detail.block.connectedState.asTBlock();
-      const point = event.detail.coord;
-      graph.api.addBlock({
-        ...block,
-        id: `${block.id.toString()}-added-from-shadow-${Date.now()}`,
-        is: "block",
-        x: point.x,
-        y: point.y,
-      });
-    });
-  }, [graph]);
-
-  const switchNewBlockEnabled = useFn((enabled: boolean) => {
-    if (enabled) {
+  const switchNewBlockEnabled = useFn((addEnabled: boolean) => {
+    if (addEnabled) {
       newBlockLayerRef.current.enable();
       setEnabled(true);
     } else {


### PR DESCRIPTION
# Brief Summary of PR

## Key Changes

### Connection Validation
- Added `isConnectionAllowed` function to ConnectionLayer that validates if a connection can be created from a source component
- Updated event documentation with more detailed information about connection events and how they can be prevented

### Block Duplication Validation
- Added `isDuplicateAllowed` function to NewBlockLayer that validates if a block can be duplicated
- Implemented validation logic that checks each block before duplication and cancels the process if no blocks can be duplicated

### Group Block Duplication
- Added support for duplicating multiple blocks at once when a selected block is Alt+dragged
- Implemented two duplication modes:
  1. "Single block duplication": When Alt+dragging a non-selected block, only that block is duplicated
  2. "Multiple block duplication": When Alt+dragging a selected block, all selected blocks are duplicated together
- Updated event types to handle multiple blocks instead of a single block
- Added code to maintain the relative positions of blocks during group duplication

### Technical Improvements
- Added AbortController integration for ConnectionLayer and NewBlockLayer for proper handling of operation cancellations
- Updated documentation to reflect the new functionality
- Fixed a bug with `addLayer` that was causing unnecessary graph re-renders