### PR TITLE
fix(Group): stop click event propagation to prevent selection reset

### DIFF
--- a/src/components/canvas/groups/Group.ts
+++ b/src/components/canvas/groups/Group.ts
@@ -101,6 +101,7 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
     this.subscribeToGroup();
 
     this.addEventListener("click", (event: MouseEvent) => {
+      event.stopPropagation();
       this.groupState.setSelection(
         true,
         !isMetaKeyEvent(event) ? ESelectionStrategy.REPLACE : ESelectionStrategy.APPEND


### PR DESCRIPTION
Clicking on a Group component triggered its selection logic, but the event propagated to the camera component, which resets all selections on click. This caused the group selection to be immediately cleared.

Added event.stopPropagation() to the Group's click listener to prevent the event from reaching the camera and preserve the selection state.