### PR TITLE
chore: Make library more SSR-friendly

### DIFF
--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -129,7 +129,7 @@ export type TGraphConstants = {
 export const initGraphConstants: TGraphConstants = {
   system: {
     GRID_SIZE: 16,
-    PIXEL_RATIO: window.devicePixelRatio || 1,
+    PIXEL_RATIO: typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1,
     USABLE_RECT_GAP: 400,
     CAMERA_VIEWPORT_TRESHOLD: 0.5,
   },

--- a/src/services/optimizations/fpsManager.ts
+++ b/src/services/optimizations/fpsManager.ts
@@ -30,7 +30,11 @@ class FpsManager {
 
       this.averageFPS = Math.floor(sum / 10);
 
-      window.requestAnimationFrame(refreshLoop);
+      if (typeof window === "undefined") {
+        global.setTimeout(refreshLoop, 16);
+      } else {
+        window.requestAnimationFrame(refreshLoop);
+      }
     };
 
     refreshLoop();

--- a/src/services/optimizations/frameDebouncer.ts
+++ b/src/services/optimizations/frameDebouncer.ts
@@ -2,7 +2,7 @@
 
 import { scheduler } from "../../lib/Scheduler";
 
-const getNowTime = window.performance.now.bind(performance);
+const getNowTime = () => performance.now();
 
 type Options = {
   delay?: number;

--- a/src/utils/Emitter.ts
+++ b/src/utils/Emitter.ts
@@ -1,9 +1,10 @@
 import { noop } from "./functions";
 
 const TIME_PER_FRAME_FOR_GC = 5; // 5 mc
-const rIC = window.requestIdleCallback || window.setTimeout;
+const globalObject = typeof window === "undefined" ? global : window;
+const rIC = globalObject.requestIdleCallback || globalObject.setTimeout;
 
-const getTime = () => window.performance.now();
+const getTime = () => performance.now();
 type EmitterEventsDefinition = Record<string, (...args: unknown[]) => void>;
 export class Emitter<T extends EmitterEventsDefinition = EmitterEventsDefinition> {
   private destroyed: boolean;

--- a/src/utils/functions/text.ts
+++ b/src/utils/functions/text.ts
@@ -11,7 +11,7 @@ function canvasContextGetter() {
   return canvas.getContext("2d");
 }
 
-const getCanvasContext = memoize(canvasContextGetter, () => "stableCacheKey");
+const getCanvasContext = memoize(canvasContextGetter, () => "canvasContext");
 
 const mapTextToMeasures: Map<string, number> = new Map();
 

--- a/src/utils/functions/text.ts
+++ b/src/utils/functions/text.ts
@@ -1,13 +1,23 @@
 /* eslint-disable no-unmodified-loop-condition */
+import memoize from "lodash/memoize";
+
 export function getFontSize(fontSize, scale) {
   return (fontSize / scale) | 0;
 }
 
-const canvas: HTMLCanvasElement = document.createElement("canvas");
-const context: CanvasRenderingContext2D = canvas.getContext("2d");
+function canvasContextGetter() {
+  const canvas: HTMLCanvasElement = document.createElement("canvas");
+
+  return canvas.getContext("2d");
+}
+
+const getCanvasContext = memoize(canvasContextGetter, () => "stableCacheKey");
+
 const mapTextToMeasures: Map<string, number> = new Map();
 
 export function measureText(text, font, approximate = true): number {
+  const context = getCanvasContext();
+
   context.font = font;
 
   if (!approximate) {


### PR DESCRIPTION
If library is imported in projects using server side rendering, all `document`/`window` usages become a problem for user regardless of the fact that there is no calls of graph rendering code on server.