### PR TITLE
fix: update anchors before geometry to fix React positioning

### DIFF
--- a/src/store/block/Block.ts
+++ b/src/store/block/Block.ts
@@ -1,5 +1,5 @@
-import { computed, signal } from "@preact/signals-core";
 import type { Signal } from "@preact/signals-core";
+import { computed, signal } from "@preact/signals-core";
 import cloneDeep from "lodash/cloneDeep";
 
 import { TAnchor } from "../../components/canvas/anchors";
@@ -143,10 +143,12 @@ export class BlockState<T extends TBlock = TBlock> {
   }
 
   public updateBlock(block: Partial<TBlock>): void {
-    this.$state.value = Object.assign({}, this.$state.value, block);
+    // Update anchors first to ensure they have correct state when geometry changes
     if (block.anchors) {
       this.updateAnchors(block.anchors);
     }
+
+    this.$state.value = Object.assign({}, this.$state.value, block);
     this.getViewComponent()?.updateHitBox(this.$geometry.value, true);
   }
 


### PR DESCRIPTION
## Fix: Anchor Position Sync Between Canvas and React Modes

### Problem
When updating blocks with anchors in React mode, anchor positions were not updating correctly after block changes. This was causing anchors to appear in wrong positions when switching between Canvas and React rendering modes.

### Root Cause
The issue occurred due to incorrect order of operations in `BlockState.updateBlock()`:

1. Block state was updated first (`this.$state.value = ...`)
2. This triggered `$geometry` computed signal change
3. React components subscribed to `$geometry` changes called `refreshAnchorPosition()`
4. But anchor states were still outdated at this point
5. Only after that, `updateAnchors()` was called to update anchor states
6. React components didn't re-render because they received the same `AnchorState` object instances

### Solution
Reordered operations in `BlockState.updateBlock()`:

1. Update anchors first with `updateAnchors()` 
2. Then update main block state
3. Now when `$geometry` change triggers React updates, anchor states are already current

### Result
- Anchor positions now sync correctly between Canvas and React modes
- No performance impact - just changed the order of existing operations
- Maintains backward compatibility

## Summary by Sourcery

Bug Fixes:
- Fix anchor positions not updating correctly when switching between Canvas and React modes.