### PR TITLE
fix(zoom): return valid rect instead of Infinity when blocks not found

### DIFF
--- a/src/api/PublicGraphApi.ts
+++ b/src/api/PublicGraphApi.ts
@@ -8,7 +8,7 @@ import { selectBlockById } from "../store/block/selectors";
 import { TConnection, TConnectionId } from "../store/connection/ConnectionState";
 import { selectConnectionById } from "../store/connection/selectors";
 import { TGraphSettingsConfig } from "../store/settings";
-import { getUsableRectByBlockIds, startAnimation } from "../utils/functions";
+import { getBlocksRect, startAnimation } from "../utils/functions";
 import { TRect } from "../utils/types/shapes";
 import { ESelectionStrategy } from "../utils/types/types";
 
@@ -23,8 +23,11 @@ export class PublicGraphApi {
   }
 
   public zoomToBlocks(blockIds: TBlockId[], zoomConfig?: ZoomConfig) {
-    const blocksRect = getUsableRectByBlockIds(this.graph.rootStore.blocksList.$blocks.value, blockIds);
-
+    const blocks = blockIds.map((id) => this.graph.rootStore.blocksList.$blocksMap.value.get(id)).filter(Boolean);
+    if (blocks.length === 0) {
+      return;
+    }
+    const blocksRect = getBlocksRect(blocks.map((block) => block.asTBlock()));
     this.zoomToRect(blocksRect, zoomConfig);
   }
 

--- a/src/components/canvas/blocks/Block.ts
+++ b/src/components/canvas/blocks/Block.ts
@@ -20,7 +20,10 @@ import { BlockController } from "./controllers/BlockController";
 
 export type TBlockSettings = {
   /** Phantom blocks are blocks whose dimensions and position
-   * are not taken into account when calculating the usable rect. */
+   * are not taken into account when calculating the usable rect.
+   *
+   * @deprecated phantom blocks are not used anymore. Please create an issue if you need this feature.
+   */
   phantom?: boolean;
 };
 

--- a/src/components/canvas/groups/BlockGroups.ts
+++ b/src/components/canvas/groups/BlockGroups.ts
@@ -6,7 +6,7 @@ import { TComponentState } from "../../../lib/Component";
 import { Layer, LayerContext, LayerProps } from "../../../services/Layer";
 import { BlockState } from "../../../store/block/Block";
 import { GroupState, TGroup, TGroupId } from "../../../store/group/Group";
-import { getUsableRectByBlockIds } from "../../../utils/functions";
+import { getBlocksRect } from "../../../utils/functions";
 import { TRect } from "../../../utils/types/shapes";
 
 import { Group } from "./Group";
@@ -53,7 +53,7 @@ export class BlockGroups<P extends BlockGroupsProps = BlockGroupsProps> extends 
           computed<TGroup[]>(() => {
             const groupedBlocks = this.$groupsBlocksMap.value;
             return Object.entries(groupedBlocks).map(([key, blocks]) =>
-              mapToGroups(key, { blocks, rect: getUsableRectByBlockIds(blocks) })
+              mapToGroups(key, { blocks, rect: getBlocksRect(blocks.map((block) => block.asTBlock())) })
             );
           }),
           (groups: TGroup[]) => {

--- a/src/components/canvas/layers/graphLayer/GraphLayer.ts
+++ b/src/components/canvas/layers/graphLayer/GraphLayer.ts
@@ -59,7 +59,7 @@ export class GraphLayer extends Layer<TGraphLayerProps, TGraphLayerContext> {
 
   private pointerPressed = false;
 
-  private eventByTargetComponent?: EventedComponent | MouseEvent;
+  private eventByTargetComponent?: MouseEvent;
 
   private capturedTargetComponent?: EventedComponent;
 

--- a/src/utils/functions/getBlocksRect.test.ts
+++ b/src/utils/functions/getBlocksRect.test.ts
@@ -1,0 +1,89 @@
+import { TBlock } from "../../components/canvas/blocks/Block";
+import { Rect } from "../types/shapes";
+
+import { getBlocksRect } from "./index";
+
+describe("getBlocksRect", () => {
+  const createMockTBlock = (id: string, x: number, y: number, width: number, height: number): TBlock => ({
+    id,
+    is: "Block",
+    x,
+    y,
+    width,
+    height,
+    selected: false,
+    name: `Block ${id}`,
+    anchors: [],
+    settings: {
+      phantom: false,
+    },
+  });
+
+  it("should return correct rect for single block", () => {
+    const blocks = [createMockTBlock("block1", 10, 20, 100, 50)];
+    const result = getBlocksRect(blocks);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(10);
+    expect(result.y).toBe(20);
+    expect(result.width).toBe(100);
+    expect(result.height).toBe(50);
+  });
+
+  it("should return correct rect for multiple blocks", () => {
+    const blocks = [createMockTBlock("block1", 10, 20, 100, 50), createMockTBlock("block2", 50, 30, 80, 60)];
+    const result = getBlocksRect(blocks);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(10);
+    expect(result.y).toBe(20);
+    expect(result.width).toBe(120); // 50 + 80
+    expect(result.height).toBe(70); // 30 + 60 - 20
+  });
+
+  it("should return default rect when blocks array is empty", () => {
+    const result = getBlocksRect([]);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+
+  it("should handle blocks with negative coordinates", () => {
+    const blocks = [createMockTBlock("block1", -10, -20, 100, 50), createMockTBlock("block2", 50, 30, 80, 60)];
+    const result = getBlocksRect(blocks);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(-10);
+    expect(result.y).toBe(-20);
+    expect(result.width).toBe(140); // 50 + 80
+    expect(result.height).toBe(110); // 30 + 60 - (-20)
+  });
+
+  it("should handle single block with zero dimensions", () => {
+    const blocks = [createMockTBlock("block1", 0, 0, 0, 0)];
+    const result = getBlocksRect(blocks);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+
+  it("should handle blocks with very large coordinates", () => {
+    const blocks = [
+      createMockTBlock("block1", 1000000, 2000000, 100, 50),
+      createMockTBlock("block2", 1000100, 2000050, 80, 60),
+    ];
+    const result = getBlocksRect(blocks);
+
+    expect(result).toBeInstanceOf(Rect);
+    expect(result.x).toBe(1000000);
+    expect(result.y).toBe(2000000);
+    expect(result.width).toBe(180); // 100 + 80
+    expect(result.height).toBe(110); // 50 + 60
+  });
+});


### PR DESCRIPTION
- Rename getUsableRectByBlockIds to getBlocksRect
- Change interface from BlockState[] to TBlock[]
- Add Infinity value checks to prevent camera NaN state
- Fix issue #114 where zoomTo with invalid blockIds broke camera