### PR TITLE
feat: make selected and anchors fields optional in TBlock type

### DIFF
--- a/docs/react/usage.md
+++ b/docs/react/usage.md
@@ -418,7 +418,7 @@ function BlockComponent({ block, graph }: { block: TBlock; graph: Graph }) {
       </div>
 
       {/* Render anchors */}
-      {block.anchors.map(anchor => (
+      {block.anchors?.map(anchor => (
         <GraphBlockAnchor
           key={anchor.id}
           graph={graph}

--- a/src/components/canvas/blocks/Block.ts
+++ b/src/components/canvas/blocks/Block.ts
@@ -41,7 +41,7 @@ export type TBlock<T extends Record<string, unknown> = {}> = {
   height: number;
   selected?: boolean;
   name: string;
-  anchors: TAnchor[];
+  anchors?: TAnchor[];
   settings?: TBlockSettings;
   meta?: T;
 };

--- a/src/components/canvas/blocks/Block.ts
+++ b/src/components/canvas/blocks/Block.ts
@@ -39,7 +39,7 @@ export type TBlock<T extends Record<string, unknown> = {}> = {
   group?: string;
   width: number;
   height: number;
-  selected: boolean;
+  selected?: boolean;
   name: string;
   anchors: TAnchor[];
   settings?: TBlockSettings;

--- a/src/stories/main/Block.tsx
+++ b/src/stories/main/Block.tsx
@@ -27,7 +27,7 @@ export const BlockStory: React.FC<TBlockStoryProps> = ({ graph, block }) => {
           {block.name}
         </Text>
       </div>
-      {block.anchors.map((anchor) => {
+      {block.anchors?.map((anchor) => {
         return (
           <GraphBlockAnchor
             className="block-anchor"


### PR DESCRIPTION
Currently, this field must be specified when adding or updating a block, which is not necessary, since it is initialized at the event anyway.