### PR TITLE
refactor(HitTest): remove unnecessary check for empty usableRect in updateUsableRect method

### DIFF
--- a/src/services/HitTest.ts
+++ b/src/services/HitTest.ts
@@ -190,10 +190,6 @@ export class HitTest extends Emitter {
   protected updateUsableRect() {
     // Use optimized tracker for elements affecting usableRect
     const rect = this.usableRectTracker.toJSON();
-    if (rect.length === 0) {
-      this.$usableRect.value = { x: 0, y: 0, width: 0, height: 0 };
-      return;
-    }
     const usableRect = {
       x: Number.isFinite(rect.minX) ? rect.minX : 0,
       y: Number.isFinite(rect.minY) ? rect.minY : 0,


### PR DESCRIPTION
Fix unnecessary object creation in HitTest.updateUsableRect()

Problem:
- When no elements affect usableRect (rect.length === 0), the method created a new object { x: 0, y: 0, width: 0, height: 0 } every time
- This caused false positive notifications to $usableRect subscribers even when values didn't actually change
- Could potentially cause update cycles with components, which subscribe to $usableRect changes and update their positions by it

Solution:
- Removed the early return for rect.length === 0 case
- The existing logic already handles empty rect correctly: Number.isFinite(undefined) returns false, so all values default to 0
- The comparison check at the end prevents unnecessary updates when values haven't changed
- Simplifies code and eliminates false positive notifications