### PR TITLE
fix(HitTest): fix infinite wait for empty graph usableRect update

### DIFF
--- a/src/api/PublicGraphApi.ts
+++ b/src/api/PublicGraphApi.ts
@@ -10,7 +10,7 @@ import { TConnection, TConnectionId } from "../store/connection/ConnectionState"
 import { selectConnectionById } from "../store/connection/selectors";
 import { TGraphSettingsConfig } from "../store/settings";
 import { getBlocksRect, startAnimation } from "../utils/functions";
-import { TRect } from "../utils/types/shapes";
+import { Rect, TRect } from "../utils/types/shapes";
 
 export type ZoomConfig = {
   transition?: number;
@@ -40,6 +40,21 @@ export class PublicGraphApi {
    */
   public zoomToViewPort(zoomConfig?: ZoomConfig) {
     this.graph.hitTest.waitUsableRectUpdate((rect) => {
+      /**
+       * if there no usableRect (maybe no blocks and connections on graph)
+       * and user call zoomToViewPort
+       * we zoom him around 0,0 point with USABLE_RECT_GAP gap
+       */
+      if (rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0) {
+        const x = 0 - this.graph.graphConstants.system.USABLE_RECT_GAP;
+        const y = 0 - this.graph.graphConstants.system.USABLE_RECT_GAP;
+        const width = 0 + this.graph.graphConstants.system.USABLE_RECT_GAP * 2;
+        const height = 0 + this.graph.graphConstants.system.USABLE_RECT_GAP * 2;
+
+        const initRect = new Rect(x, y, width, height);
+        this.zoomToRect(initRect, zoomConfig);
+        return;
+      }
       this.zoomToRect(rect, zoomConfig);
     });
   }

--- a/src/services/HitTest.ts
+++ b/src/services/HitTest.ts
@@ -62,14 +62,7 @@ export class HitTest extends Emitter {
   protected queue = new Map<HitBox, HitBoxData | null>();
 
   public get isUnstable() {
-    return (
-      this.processQueue.isScheduled() ||
-      this.queue.size > 0 ||
-      (this.$usableRect.value.height === 0 &&
-        this.$usableRect.value.width === 0 &&
-        this.$usableRect.value.x === 0 &&
-        this.$usableRect.value.y === 0)
-    );
+    return this.processQueue.isScheduled() || this.queue.size > 0;
   }
 
   /**


### PR DESCRIPTION
## Issue
Empty graph with `usableRect = {x: 0, y: 0, width: 0, height: 0}` caused `isUnstable` to always return `true` due to zero values validation. This led to infinite waiting in `waitUsableRectUpdate()` and prevented components like `Background` from proper initialization.

## Solution  
Removed zero values check from `isUnstable` getter. Empty graph state is a valid stable condition - system should be considered unstable only when actively processing updates (`processQueue.isScheduled()` or `queue.size > 0`).