### PR TITLE
feat: Introduce CursorLayer

### DIFF
--- a/src/components/canvas/GraphComponent/index.tsx
+++ b/src/components/canvas/GraphComponent/index.tsx
@@ -133,6 +133,7 @@ export class GraphComponent<
             return;
           }
           this.context.graph.getGraphLayer().captureEvents(this);
+          this.context.graph.lockCursor("grabbing");
           const xy = getXY(this.context.canvas, event);
           startDragCoords = this.context.camera.applyToPoint(xy[0], xy[1]);
         })
@@ -150,6 +151,7 @@ export class GraphComponent<
         })
         .on(EVENTS.DRAG_END, (_event: MouseEvent) => {
           this.context.graph.getGraphLayer().releaseCapture();
+          this.context.graph.unlockCursor();
           startDragCoords = undefined;
           onDrop?.(_event);
         });

--- a/src/components/canvas/blocks/Block.ts
+++ b/src/components/canvas/blocks/Block.ts
@@ -93,6 +93,8 @@ export class Block<T extends TBlock = TBlock, Props extends TBlockProps = TBlock
 > {
   public static IS = IS_BLOCK_TYPE;
 
+  public cursor?: string = "pointer";
+
   // from controller mixin
   public readonly isBlock = true;
 

--- a/src/components/canvas/blocks/controllers/BlockController.ts
+++ b/src/components/canvas/blocks/controllers/BlockController.ts
@@ -61,6 +61,7 @@ export class BlockController {
       dragListener(block.context.ownerDocument)
         .on(EVENTS.DRAG_START, (_event: MouseEvent) => {
           block.context.graph.getGraphLayer().captureEvents(block);
+          block.context.graph.lockCursor("grabbing");
           dispatchEvents(draggingElements, createCustomDragEvent(EVENTS.DRAG_START, _event));
         })
         .on(EVENTS.DRAG_UPDATE, (_event: MouseEvent) => {
@@ -68,6 +69,7 @@ export class BlockController {
         })
         .on(EVENTS.DRAG_END, (_event: MouseEvent) => {
           block.context.graph.getGraphLayer().releaseCapture();
+          block.context.graph.unlockCursor();
           dispatchEvents(draggingElements, createCustomDragEvent(EVENTS.DRAG_END, _event));
         });
     });

--- a/src/components/canvas/layers/connectionLayer/ConnectionLayer.ts
+++ b/src/components/canvas/layers/connectionLayer/ConnectionLayer.ts
@@ -200,14 +200,16 @@ export class ConnectionLayer extends Layer<
       nativeEvent.stopPropagation();
       dragListener(this.root.ownerDocument)
         .on(EVENTS.DRAG_START, (dStartEvent: MouseEvent) => {
+          this.context.graph.lockCursor("crosshair");
           this.onStartConnection(dStartEvent, this.context.graph.getPointInCameraSpace(dStartEvent));
         })
         .on(EVENTS.DRAG_UPDATE, (dUpdateEvent: MouseEvent) =>
           this.onMoveNewConnection(dUpdateEvent, this.context.graph.getPointInCameraSpace(dUpdateEvent))
         )
-        .on(EVENTS.DRAG_END, (dEndEvent: MouseEvent) =>
-          this.onEndNewConnection(this.context.graph.getPointInCameraSpace(dEndEvent))
-        );
+        .on(EVENTS.DRAG_END, (dEndEvent: MouseEvent) => {
+          this.context.graph.unlockCursor();
+          this.onEndNewConnection(this.context.graph.getPointInCameraSpace(dEndEvent));
+        });
     }
   };
 

--- a/src/components/canvas/layers/cursorLayer/CursorLayer.ts
+++ b/src/components/canvas/layers/cursorLayer/CursorLayer.ts
@@ -1,0 +1,344 @@
+import { Graph } from "../../../../graph";
+import { Layer, LayerContext, LayerProps } from "../../../../services/Layer";
+import { EventedComponent } from "../../EventedComponent/EventedComponent";
+import { GraphComponent } from "../../GraphComponent";
+
+/**
+ * All supported CSS cursor types for the CursorLayer.
+ * Includes standard CSS cursor values and additional browser-specific cursors.
+ */
+export type CursorLayerCursorTypes =
+  | "auto"
+  | "default"
+  | "pointer"
+  | "crosshair"
+  | "move"
+  | "text"
+  | "wait"
+  | "help"
+  | "e-resize"
+  | "n-resize"
+  | "ne-resize"
+  | "nw-resize"
+  | "s-resize"
+  | "se-resize"
+  | "sw-resize"
+  | "w-resize"
+  | "ew-resize"
+  | "ns-resize"
+  | "nesw-resize"
+  | "nwse-resize"
+  | "grab"
+  | "grabbing"
+  | "not-allowed"
+  | "no-drop"
+  | "copy"
+  | "alias"
+  | "context-menu"
+  | "cell"
+  | "col-resize"
+  | "row-resize"
+  | "progress"
+  | "vertical-text"
+  | "zoom-in"
+  | "zoom-out";
+
+/**
+ * Operating modes for the CursorLayer.
+ * - "auto": Automatically sets cursor based on component under mouse
+ * - "manual": Uses manually set cursor, ignoring component cursors
+ */
+export type CursorLayerMode = "auto" | "manual";
+
+/**
+ * Properties for CursorLayer configuration.
+ */
+export type TCursorLayerProps = LayerProps & {
+  graph: Graph;
+};
+
+/**
+ * Context provided to CursorLayer during rendering.
+ */
+export type TCursorLayerContext = LayerContext & {
+  html: HTMLDivElement;
+  graph: Graph;
+};
+
+/**
+ * CursorLayer provides cursor management for graph components.
+ *
+ * This layer solves performance issues with cursor changes by using a dedicated
+ * HTML overlay instead of modifying the root element's cursor style, which can
+ * cause expensive style recalculations.
+ *
+ * ## Features:
+ * - **Automatic mode**: Dynamically sets cursor based on component under mouse
+ * - **Manual mode**: Allows explicit cursor control that overrides automatic behavior
+ *
+ * ## Usage:
+ * ```typescript
+ * // Automatic mode (default)
+ * graph.getCursorLayer().isAuto(); // true
+ *
+ * // Manual mode
+ * graph.setCursor("grabbing");
+ * graph.unsetCursor(); // returns to auto mode
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // The layer is automatically created and managed by the Graph
+ * const cursorLayer = graph.getCursorLayer();
+ *
+ * // Check current mode
+ * console.log(cursorLayer.getMode()); // "auto" | "manual"
+ *
+ * // Set manual cursor
+ * cursorLayer.setCursor("wait");
+ *
+ * // Return to automatic behavior
+ * cursorLayer.unsetCursor();
+ * ```
+ */
+export class CursorLayer extends Layer<TCursorLayerProps, TCursorLayerContext> {
+  /** Current operating mode of the cursor layer */
+  private mode: CursorLayerMode = "auto";
+
+  /** Currently set manual cursor type (only used in manual mode) */
+  private manualCursor?: CursorLayerCursorTypes;
+
+  /** Component currently under the mouse cursor */
+  private currentTarget?: GraphComponent;
+
+  /**
+   * Creates a new CursorLayer instance.
+   *
+   * @param props - Configuration props for the layer
+   */
+  constructor(props: TCursorLayerProps) {
+    super({
+      html: {
+        zIndex: 1000, // Above all other layers
+        classNames: ["cursor-layer"],
+      },
+      ...props,
+    });
+  }
+
+  /**
+   * Lifecycle method called after layer initialization.
+   * Sets up event listeners for mouse tracking.
+   */
+  protected afterInit(): void {
+    super.afterInit();
+
+    // Always subscribe to graph events for mouse position tracking
+    // Cursor is only applied in automatic mode
+    this.subscribeToGraphEvents();
+  }
+
+  /**
+   * Subscribes to graph mouse events for cursor management.
+   * Always tracks mouse position to maintain accurate state
+   * when switching between manual and auto modes.
+   *
+   * @private
+   */
+  private subscribeToGraphEvents(): void {
+    // Subscribe to mouseenter and mouseleave events from the graph
+    // ALWAYS track state to know where the mouse is located
+    this.onGraphEvent("mouseenter", (event) => {
+      const target = event.detail?.target;
+
+      // Always track the current target
+      this.currentTarget = target as GraphComponent;
+
+      // Apply cursor only in automatic mode
+      if (this.mode === "auto") {
+        this.updateCursorForTarget(target);
+      }
+    });
+
+    this.onGraphEvent("mouseleave", () => {
+      // Always track that mouse left the element
+      this.currentTarget = undefined;
+
+      // Apply cursor only in automatic mode
+      if (this.mode === "auto") {
+        this.applyCursor("auto");
+      }
+    });
+  }
+
+  /**
+   * Updates the cursor based on the target component's cursor property.
+   *
+   * @param target - The component under the mouse cursor
+   * @private
+   */
+  private updateCursorForTarget(target?: EventedComponent): void {
+    if (target && typeof target.isInteractive === "function" && target.isInteractive() && target.cursor) {
+      this.applyCursor(target.cursor as CursorLayerCursorTypes);
+    } else {
+      this.applyCursor("auto");
+    }
+  }
+
+  /**
+   * Applies the specified cursor to the HTML layer element.
+   *
+   * @param cursor - The cursor type to apply
+   * @private
+   */
+  private applyCursor(cursor: CursorLayerCursorTypes): void {
+    const htmlElement = this.getHTML();
+    if (htmlElement) {
+      htmlElement.style.cursor = cursor;
+    }
+  }
+
+  /**
+   * Locks the cursor to a specific type, disabling automatic cursor changes.
+   *
+   * When locked, the cursor will not change automatically based on
+   * component interactions until unlockCursor() is called. This effectively
+   * "freezes" the cursor state until manually unlocked.
+   *
+   * @param cursor - The cursor type to lock to
+   *
+   * @example
+   * ```typescript
+   * // Lock to loading cursor during async operation
+   * cursorLayer.lockCursor("wait");
+   *
+   * // Lock to grabbing cursor during drag
+   * cursorLayer.lockCursor("grabbing");
+   * ```
+   *
+   * @see {@link unlockCursor} to return to automatic behavior
+   */
+  public lockCursor(cursor: CursorLayerCursorTypes): void {
+    this.mode = "manual";
+    this.manualCursor = cursor;
+    this.applyCursor(cursor);
+  }
+
+  /**
+   * Unlocks the cursor and returns to automatic cursor management.
+   *
+   * The cursor will immediately update to reflect the current state
+   * based on the component under the mouse (if any). This removes the
+   * "lock" and allows the cursor to respond to component interactions again.
+   *
+   * @example
+   * ```typescript
+   * // Unlock to return to automatic behavior
+   * cursorLayer.unlockCursor();
+   *
+   * // If mouse is over a block, cursor will immediately show "grab"
+   * // If mouse is over empty space, cursor will show "auto"
+   * ```
+   *
+   * @see {@link lockCursor} to disable automatic behavior
+   */
+  public unlockCursor(): void {
+    this.mode = "auto";
+    this.manualCursor = undefined;
+
+    // Immediately apply the correct cursor for the current state
+    if (this.currentTarget) {
+      this.updateCursorForTarget(this.currentTarget);
+    } else {
+      this.applyCursor("auto");
+    }
+  }
+
+  /**
+   * Returns the current operating mode of the cursor layer.
+   *
+   * @returns The current mode ("auto" or "manual")
+   *
+   * @example
+   * ```typescript
+   * if (cursorLayer.getMode() === "manual") {
+   *   console.log("Cursor is manually controlled");
+   * }
+   * ```
+   */
+  public getMode(): CursorLayerMode {
+    return this.mode;
+  }
+
+  /**
+   * Returns the currently set manual cursor type.
+   *
+   * @returns The manual cursor type, or undefined if not in manual mode
+   *
+   * @example
+   * ```typescript
+   * const manualCursor = cursorLayer.getManualCursor();
+   * if (manualCursor) {
+   *   console.log(`Manual cursor: ${manualCursor}`);
+   * }
+   * ```
+   */
+  public getManualCursor(): CursorLayerCursorTypes | undefined {
+    return this.manualCursor;
+  }
+
+  /**
+   * Checks if the cursor layer is currently in manual mode.
+   *
+   * @returns True if in manual mode, false otherwise
+   *
+   * @example
+   * ```typescript
+   * if (cursorLayer.isManual()) {
+   *   // Manual cursor is active
+   *   console.log("Manual cursor:", cursorLayer.getManualCursor());
+   * }
+   * ```
+   */
+  public isManual(): boolean {
+    return this.mode === "manual";
+  }
+
+  /**
+   * Checks if the cursor layer is currently in automatic mode.
+   *
+   * @returns True if in automatic mode, false otherwise
+   *
+   * @example
+   * ```typescript
+   * if (cursorLayer.isAuto()) {
+   *   // Cursor changes automatically based on components
+   *   console.log("Current target:", cursorLayer.getCurrentTarget());
+   * }
+   * ```
+   */
+  public isAuto(): boolean {
+    return this.mode === "auto";
+  }
+
+  /**
+   * Returns the component currently under the mouse cursor.
+   *
+   * This method is primarily intended for debugging and development.
+   * The value is tracked regardless of the current mode.
+   *
+   * @returns The component under the cursor, or undefined if none
+   *
+   * @example
+   * ```typescript
+   * const target = cursorLayer.getCurrentTarget();
+   * if (target) {
+   *   console.log("Mouse over:", target.constructor.name);
+   *   console.log("Component cursor:", target.cursor);
+   * }
+   * ```
+   */
+  public getCurrentTarget(): EventedComponent | undefined {
+    return this.currentTarget;
+  }
+}

--- a/src/components/canvas/layers/cursorLayer/index.ts
+++ b/src/components/canvas/layers/cursorLayer/index.ts
@@ -1,0 +1,7 @@
+export {
+  CursorLayer,
+  type CursorLayerCursorTypes,
+  type CursorLayerMode,
+  type TCursorLayerProps,
+  type TCursorLayerContext,
+} from "./CursorLayer";

--- a/src/components/canvas/layers/graphLayer/GraphLayer.ts
+++ b/src/components/canvas/layers/graphLayer/GraphLayer.ts
@@ -226,11 +226,6 @@ export class GraphLayer extends Layer<TGraphLayerProps, TGraphLayerContext> {
 
   private onRootPointerMove(event: MouseEvent) {
     if (this.targetComponent !== this.prevTargetComponent) {
-      if (this.targetComponent?.isInteractive() && this.targetComponent?.cursor) {
-        this.root.style.cursor = this.targetComponent?.cursor;
-      } else {
-        this.root.style.removeProperty("cursor");
-      }
       this.applyEventToTargetComponent(
         new CustomEvent("mouseleave", {
           bubbles: false,

--- a/src/components/canvas/layers/newBlockLayer/NewBlockLayer.ts
+++ b/src/components/canvas/layers/newBlockLayer/NewBlockLayer.ts
@@ -111,11 +111,15 @@ export class NewBlockLayer extends Layer<
       nativeEvent.preventDefault();
       nativeEvent.stopPropagation();
       dragListener(this.root.ownerDocument)
-        .on(EVENTS.DRAG_START, (event: MouseEvent) => this.onStartNewBlock(event, target))
+        .on(EVENTS.DRAG_START, (event: MouseEvent) => {
+          this.context.graph.lockCursor("copy");
+          this.onStartNewBlock(event, target);
+        })
         .on(EVENTS.DRAG_UPDATE, (event: MouseEvent) => this.onMoveNewBlock(event))
-        .on(EVENTS.DRAG_END, (event: MouseEvent) =>
-          this.onEndNewBlock(event, this.context.graph.getPointInCameraSpace(event))
-        );
+        .on(EVENTS.DRAG_END, (event: MouseEvent) => {
+          this.context.graph.unlockCursor();
+          this.onEndNewBlock(event, this.context.graph.getPointInCameraSpace(event));
+        });
     }
   };
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -5,6 +5,7 @@ import { PublicGraphApi, ZoomConfig } from "./api/PublicGraphApi";
 import { GraphComponent } from "./components/canvas/GraphComponent";
 import { TBlock } from "./components/canvas/blocks/Block";
 import { BelowLayer } from "./components/canvas/layers/belowLayer/BelowLayer";
+import { CursorLayer, CursorLayerCursorTypes } from "./components/canvas/layers/cursorLayer";
 import { GraphLayer } from "./components/canvas/layers/graphLayer/GraphLayer";
 import { SelectionLayer } from "./components/canvas/layers/selectionLayer/SelectionLayer";
 import { TGraphColors, TGraphConstants, initGraphColors, initGraphConstants } from "./graphConfig";
@@ -64,6 +65,8 @@ export class Graph {
 
   protected selectionLayer: SelectionLayer;
 
+  protected cursorLayer: CursorLayer;
+
   public getGraphCanvas() {
     return this.graphLayer.getCanvas();
   }
@@ -107,6 +110,7 @@ export class Graph {
     this.belowLayer = this.addLayer(BelowLayer, {});
     this.graphLayer = this.addLayer(GraphLayer, {});
     this.selectionLayer = this.addLayer(SelectionLayer, {});
+    this.cursorLayer = this.addLayer(CursorLayer, {});
 
     this.selectionLayer.hide();
     this.graphLayer.hide();
@@ -384,6 +388,7 @@ export class Graph {
       this.selectionLayer.show();
       this.graphLayer.show();
       this.belowLayer.show();
+      this.cursorLayer.show();
     });
   }
 
@@ -430,5 +435,88 @@ export class Graph {
     clearTextCache();
     this.rootStore.reset();
     this.scheduler.stop();
+  }
+
+  /**
+   * Locks the cursor to a specific type, disabling automatic cursor changes.
+   *
+   * When the cursor is locked, it will remain fixed to the specified type
+   * and will not change automatically based on component interactions until
+   * unlockCursor() is called. This is useful during drag operations, loading
+   * states, or other situations where you want to override the default
+   * interactive cursor behavior.
+   *
+   * @param cursor - The cursor type to lock to
+   *
+   * @example
+   * ```typescript
+   * // Lock to loading cursor during async operation
+   * graph.lockCursor("wait");
+   *
+   * // Lock to grabbing cursor during drag operation
+   * graph.lockCursor("grabbing");
+   *
+   * // Lock to copy cursor for duplication operations
+   * graph.lockCursor("copy");
+   * ```
+   *
+   * @see {@link CursorLayer.lockCursor} for more details
+   * @see {@link unlockCursor} to return to automatic behavior
+   */
+  public lockCursor(cursor: CursorLayerCursorTypes): void {
+    this.cursorLayer.lockCursor(cursor);
+  }
+
+  /**
+   * Unlocks the cursor and returns to automatic cursor management.
+   *
+   * The cursor will immediately update to reflect the current state
+   * based on the component under the mouse (if any). This provides
+   * smooth transitions when ending drag operations or async tasks.
+   *
+   * @example
+   * ```typescript
+   * // After completing a drag operation
+   * graph.unlockCursor(); // Will show appropriate cursor for current hover state
+   *
+   * // After finishing an async operation
+   * await someAsyncTask();
+   * graph.unlockCursor(); // Returns to interactive cursor behavior
+   * ```
+   *
+   * @see {@link CursorLayer.unlockCursor} for more details
+   * @see {@link lockCursor} to override automatic behavior
+   */
+  public unlockCursor(): void {
+    this.cursorLayer.unlockCursor();
+  }
+
+  /**
+   * Returns the CursorLayer instance for advanced cursor management.
+   *
+   * Use this method when you need direct access to cursor layer functionality
+   * beyond the basic setCursor/unsetCursor API, such as checking the current
+   * mode or getting the component under the cursor.
+   *
+   * @returns The CursorLayer instance
+   *
+   * @example
+   * ```typescript
+   * const cursorLayer = graph.getCursorLayer();
+   *
+   * // Check current mode
+   * if (cursorLayer.isManual()) {
+   *   console.log("Manual cursor:", cursorLayer.getManualCursor());
+   * }
+   *
+   * // Get component under cursor for debugging
+   * const target = cursorLayer.getCurrentTarget();
+   * console.log("Hovering over:", target?.constructor.name);
+   * ```
+   *
+   * @see {@link CursorLayer} for available methods and properties
+   */
+  public getCursorLayer(): CursorLayer {
+    return this.cursorLayer;
   }
 }


### PR DESCRIPTION
# Add CursorLayer for Performance-Optimized Cursor Management

## Problem

The current cursor management system sets cursor styles directly on the root DOM element, which triggers expensive style recalculations across the entire DOM tree. This causes performance issues, particularly during frequent cursor changes such as drag operations and hover interactions.

## Solution

This PR introduces a dedicated `CursorLayer` that manages cursor display through a high z-index HTML overlay, eliminating the need to modify root element styles and preventing costly DOM recalculations.

## Key Features

### Dual Operation Modes
- **Automatic mode**: Dynamically sets cursor based on component under mouse
- **Manual mode**: Allows explicit cursor control that overrides automatic behavior

### Performance Benefits
- Uses dedicated HTML layer to avoid DOM style recalculations
- Maintains smooth cursor transitions during drag operations
- Eliminates performance bottlenecks in complex graph interactions

### Smart State Management
- Always tracks mouse position for seamless mode transitions
- Immediately applies correct cursor when switching from manual to auto mode
- Provides consistent behavior across all graph interactions

## API Changes

### New Methods
```typescript
// Lock cursor to specific type (was setCursor)
graph.lockCursor("grabbing");

// Unlock and return to automatic behavior (was unsetCursor) 
graph.unlockCursor();

// Access layer for advanced functionality
const cursorLayer = graph.getCursorLayer();
```

### Integration Points
The cursor layer is automatically integrated into drag operations:
- Block drag: `grabbing` cursor
- Block duplication (Alt+drag): `copy` cursor  
- Connection creation (Shift+drag): `crosshair` cursor

## Usage Examples

### Basic Manual Control
```typescript
// Show loading state
graph.lockCursor("wait");

// Perform async operation
await someAsyncTask();

// Return to interactive behavior
graph.unlockCursor();
```

### Advanced Layer Access
```typescript
const cursorLayer = graph.getCursorLayer();

// Check current state
if (cursorLayer.isManual()) {
  console.log("Cursor locked to:", cursorLayer.getManualCursor());
}

// Get component under cursor for debugging
const target = cursorLayer.getCurrentTarget();
```

## Implementation Details

- `CursorLayer` extends the base `Layer` class following established patterns
- Subscribes to `mouseenter`/`mouseleave` graph events for automatic cursor management
- Maintains internal state tracking for smooth transitions between modes
- Provides comprehensive TypeScript types and JSDoc documentation
