### PR TITLE
feat(GraphComponent)!: provide absolute diff from drag start in onDrag callback

### DIFF
--- a/src/components/canvas/groups/BlockGroups.ts
+++ b/src/components/canvas/groups/BlockGroups.ts
@@ -111,12 +111,12 @@ export class BlockGroups<P extends BlockGroupsProps = BlockGroupsProps> extends 
     return this.props.graph.getGraphLayer().$.camera as CoreComponent;
   }
 
-  public updateBlocks = (groupId: TGroupId, { diffX, diffY }: { diffX: number; diffY: number }) => {
+  public updateBlocks = (groupId: TGroupId, { deltaX, deltaY }: { deltaX: number; deltaY: number }) => {
     if ((this.props as BlockGroupsProps & { updateBlocksOnDrag?: boolean }).updateBlocksOnDrag) {
       const blocks = this.$groupsBlocksMap.value[groupId];
       if (blocks) {
         blocks.forEach((block) => {
-          block.updateXY(block.x - diffX, block.y - diffY, true);
+          block.updateXY(block.x + deltaX, block.y + deltaY, true);
         });
       }
     }

--- a/src/components/canvas/groups/Group.ts
+++ b/src/components/canvas/groups/Group.ts
@@ -26,7 +26,7 @@ export type TGroupGeometry = {
 
 export type TGroupProps = {
   id: TGroupId;
-  onDragUpdate: (groupId: string, diff: { diffX: number; diffY: number }) => void;
+  onDragUpdate: (groupId: string, diff: { deltaX: number; deltaY: number }) => void;
   style?: Partial<TGroupStyle>;
   geometry?: Partial<TGroupGeometry>;
   draggable?: boolean;
@@ -114,10 +114,10 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
         this.context.graph.cameraService.enableAutoPanning();
         this.context.graph.lockCursor("grabbing");
       },
-      onDragUpdate: ({ diffX, diffY }) => {
+      onDragUpdate: ({ deltaX, deltaY }) => {
         const rect = {
-          x: this.state.rect.x - diffX,
-          y: this.state.rect.y - diffY,
+          x: this.state.rect.x + deltaX,
+          y: this.state.rect.y + deltaY,
           width: this.state.rect.width,
           height: this.state.rect.height,
         };
@@ -125,7 +125,7 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
           rect,
         });
         this.updateHitBox(rect);
-        this.props.onDragUpdate(this.props.id, { diffX, diffY });
+        this.props.onDragUpdate(this.props.id, { deltaX, deltaY });
       },
       onDrop: () => {
         this.context.graph.cameraService.disableAutoPanning();


### PR DESCRIPTION
BREAKING CHANGE: `diffX`/`diffY` in `onDragUpdate` callback now represent
absolute displacement from drag start position instead of incremental
frame-to-frame values.

Changes:
- `diffX`/`diffY` now calculated as `currentCoords - startCoords`
- Added `startCoords` - initial position when drag started
- Added `deltaX`/`deltaY` - incremental change since previous frame
- Removed integer truncation (`| 0`) for better precision with slow movements