### PR TITLE
fix: consider renderOrder in hit test sorting for overlapping blocks

### DIFF
--- a/src/services/HitTest.ts
+++ b/src/services/HitTest.ts
@@ -326,7 +326,11 @@ export class HitTest extends Emitter {
       if (aZIndex !== bZIndex) {
         return bZIndex - aZIndex;
       }
-      return 0;
+
+      const aOrder = typeof a.renderOrder === "number" ? a.renderOrder : -1;
+      const bOrder = typeof b.renderOrder === "number" ? b.renderOrder : -1;
+
+      return bOrder - aOrder;
     });
 
     return res;


### PR DESCRIPTION
When blocks with the same zIndex overlap, hit test was selecting the wrong block on click because it only sorted by zIndex without considering renderOrder.

Reproduction scenario:
1. Place two blocks at the same position (e.g., drop a new block on top of an existing one)
2. Both blocks have the same base zIndex (DEFAULT_Z_INDEX)
3. Visually, the newer block appears on top (due to higher renderOrder)
4. Click on the overlapping area
5. Bug: the older block gets selected instead of the visually top one

Root cause: testHitBox() sorted components only by zIndex, returning 0 for equal values. This preserved the original RBush tree order instead of considering renderOrder, which determines the actual visual stacking order (zIndex + renderOrder).

Fix: Added secondary sorting by renderOrder when zIndex values are equal, ensuring hit test matches the visual stacking order.