### PR TITLE
fix(drag): handle anchor drag by resolving to parent block

### DIFF
--- a/src/components/canvas/anchors/index.ts
+++ b/src/components/canvas/anchors/index.ts
@@ -1,5 +1,6 @@
 import { ESchedulerPriority } from "../../../lib";
 import { ECameraScaleLevel } from "../../../services/camera/CameraService";
+import { DragContext, DragDiff } from "../../../services/drag";
 import { AnchorState, EAnchorType } from "../../../store/anchor/Anchor";
 import { TBlockId } from "../../../store/block/Block";
 import { selectBlockAnchor } from "../../../store/block/selectors";
@@ -66,6 +67,7 @@ export class Anchor<T extends TAnchorProps = TAnchorProps> extends GraphComponen
     this.state = { size: props.size, raised: false, selected: false };
 
     this.connectedState = selectBlockAnchor(this.context.graph, props.blockId, props.id);
+    this.connectedState.setViewComponent(this);
     this.subscribeSignal(this.connectedState.$selected, (selected) => {
       this.setState({ selected });
     });
@@ -85,6 +87,22 @@ export class Anchor<T extends TAnchorProps = TAnchorProps> extends GraphComponen
 
   public toggleSelected() {
     this.connectedState.setSelection(!this.state.selected);
+  }
+
+  public override isDraggable(): boolean {
+    return true;
+  }
+
+  public override handleDragStart(context: DragContext): void {
+    this.connectedState.block.getViewComponent()?.handleDragStart(context);
+  }
+
+  public override handleDrag(diff: DragDiff, context: DragContext): void {
+    this.connectedState.block.getViewComponent()?.handleDrag(diff, context);
+  }
+
+  public override handleDragEnd(context: DragContext): void {
+    this.connectedState.block.getViewComponent()?.handleDragEnd(context);
   }
 
   protected isVisible() {

--- a/src/store/anchor/Anchor.ts
+++ b/src/store/anchor/Anchor.ts
@@ -1,6 +1,6 @@
 import { computed, signal } from "@preact/signals-core";
 
-import { TAnchor } from "../../components/canvas/anchors";
+import { Anchor, TAnchor } from "../../components/canvas/anchors";
 import { BlockState } from "../block/Block";
 
 export enum EAnchorType {
@@ -12,6 +12,8 @@ export class AnchorState {
   protected $state = signal<TAnchor>(undefined);
 
   public $selected = computed(() => this.block.store.anchorSelectionBucket.isSelected(this.id));
+
+  private anchorView: Anchor;
 
   public get id() {
     return this.$state.value.id;
@@ -37,6 +39,14 @@ export class AnchorState {
 
   public setSelection(selected: boolean) {
     this.block.onAnchorSelected(this.id, selected);
+  }
+
+  public setViewComponent(anchorComponent: Anchor) {
+    this.anchorView = anchorComponent;
+  }
+
+  public getViewComponent() {
+    return this.anchorView;
   }
 
   public asTAnchor(): TAnchor {


### PR DESCRIPTION
Fixed TypeError when dragging a block by clicking on an anchor.

Changes:
- Added view component storage to AnchorState (setViewComponent/getViewComponent)
  following the same pattern as BlockState
- Registered Anchor view component in AnchorState during Anchor construction
- Made Anchor draggable and delegate drag events to parent Block via
  handleDragStart/handleDrag/handleDragEnd overrides

This allows anchors to be dragged naturally while the parent block moves,
keeping drag logic encapsulated within the Anchor component itself.