### PR TITLE
fix: prevent preventDefault of native event on handle it in DragListener

### DIFF
--- a/src/components/canvas/layers/graphLayer/GraphLayer.ts
+++ b/src/components/canvas/layers/graphLayer/GraphLayer.ts
@@ -1,5 +1,5 @@
 import { Graph } from "../../../../graph";
-import { GraphMouseEventNames, isNativeGraphEventName } from "../../../../graphEvents";
+import { GraphMouseEventNames, isGraphEvent, isNativeGraphEventName } from "../../../../graphEvents";
 import { Component } from "../../../../lib/Component";
 import { Layer, LayerContext, LayerProps } from "../../../../services/Layer";
 import { Camera, TCameraProps } from "../../../../services/camera/Camera";
@@ -182,6 +182,9 @@ export class GraphLayer extends Layer<TGraphLayerProps, TGraphLayerContext> {
     });
     if (graphEvent.defaultPrevented) {
       event.preventDefault();
+      return false;
+    }
+    if (isGraphEvent(graphEvent) && graphEvent.graphEventPropagationStopped) {
       return false;
     }
     return true;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -9,7 +9,7 @@ import { CursorLayer, CursorLayerCursorTypes } from "./components/canvas/layers/
 import { GraphLayer } from "./components/canvas/layers/graphLayer/GraphLayer";
 import { SelectionLayer } from "./components/canvas/layers/selectionLayer/SelectionLayer";
 import { TGraphColors, TGraphConstants, initGraphColors, initGraphConstants } from "./graphConfig";
-import { GraphEventParams, GraphEventsDefinitions } from "./graphEvents";
+import { GraphEvent, GraphEventParams, GraphEventsDefinitions } from "./graphEvents";
 import { scheduler } from "./lib/Scheduler";
 import { HitTest } from "./services/HitTest";
 import { Layer, LayerPublicProps } from "./services/Layer";
@@ -329,7 +329,7 @@ export class Graph {
     Cb extends GraphEventsDefinitions[EventName] = GraphEventsDefinitions[EventName],
     P extends Parameters<Cb>[0] = Parameters<Cb>[0],
   >(eventName: EventName, detail: GraphEventParams<P>) {
-    const event = new CustomEvent(eventName, {
+    const event = new GraphEvent(eventName, {
       detail,
       bubbles: false,
       cancelable: true,

--- a/src/graphEvents.ts
+++ b/src/graphEvents.ts
@@ -61,3 +61,21 @@ export type SelectionEvent<T extends TSelectionEntityId> = CustomEvent<TSelectio
 export function isNativeGraphEventName(eventType: string): eventType is GraphMouseEventNames {
   return graphMouseEvents.includes(eventType);
 }
+export class GraphEvent<T = unknown> extends CustomEvent<T> {
+  public graphEventDefaultPrevented = false;
+  public graphEventPropagationStopped = false;
+
+  public preventGraphEventDefault() {
+    this.graphEventDefaultPrevented = true;
+  }
+
+  public stopGraphEventPropagation() {
+    this.graphEventPropagationStopped = true;
+  }
+}
+
+export function isGraphEvent<T = unknown>(event: CustomEvent<T>): event is GraphEvent<T> {
+  return (
+    event instanceof CustomEvent && "graphEventDefaultPrevented" in event && "graphEventPropagationStopped" in event
+  );
+}

--- a/src/services/drag/DragService.ts
+++ b/src/services/drag/DragService.ts
@@ -2,6 +2,7 @@ import { signal } from "@preact/signals-core";
 
 import type { GraphComponent } from "../../components/canvas/GraphComponent";
 import type { Graph } from "../../graph";
+import { isGraphEvent } from "../../graphEvents";
 import type { GraphMouseEvent } from "../../graphEvents";
 import { ECanDrag } from "../../store/settings";
 import { Emitter } from "../../utils/Emitter";
@@ -124,8 +125,9 @@ export class DragService {
       return;
     }
 
-    // Prevent camera drag when dragging components
-    event.preventDefault();
+    if (isGraphEvent(event)) {
+      event.stopGraphEventPropagation();
+    }
 
     // Reset stale emitter from previous mousedown that didn't result in drag
     this.currentDragEmitter = null;
@@ -303,7 +305,7 @@ export class DragService {
    * ```
    */
   public startDrag(callbacks: DragOperationCallbacks, options: DragOperationOptions = {}): void {
-    const { document: doc, cursor, autopanning = true, stopOnMouseLeave } = options;
+    const { document: doc, cursor, autopanning = true, stopOnMouseLeave, threshold } = options;
     const { onStart, onUpdate, onEnd } = callbacks;
 
     const targetDocument = doc ?? this.graph.getGraphCanvas().ownerDocument;
@@ -313,6 +315,7 @@ export class DragService {
       dragCursor: cursor,
       autopanning,
       stopOnMouseLeave,
+      threshold,
     })
       .on(EVENTS.DRAG_START, (event: MouseEvent) => {
         const coords = this.getWorldCoords(event);

--- a/src/services/drag/types.ts
+++ b/src/services/drag/types.ts
@@ -14,6 +14,11 @@ export type DragOperationOptions = {
   autopanning?: boolean;
   /** Stop drag when mouse leaves the document */
   stopOnMouseLeave?: boolean;
+  /**
+   * Minimum distance in pixels the mouse must move before drag starts.
+   * If not set, uses graph's dragThreshold setting.
+   */
+  threshold?: number;
 };
 
 /**

--- a/src/store/settings.test.ts
+++ b/src/store/settings.test.ts
@@ -1,6 +1,6 @@
 import { Graph } from "../graph";
 
-import { ECanChangeBlockGeometry, ECanDrag, GraphEditorSettings } from "./settings";
+import { DefaultSettings, ECanChangeBlockGeometry, ECanDrag, GraphEditorSettings } from "./settings";
 
 describe("Settings store", () => {
   let graph: Graph;
@@ -14,21 +14,7 @@ describe("Settings store", () => {
   });
 
   it("Should init with default settings", () => {
-    expect(store.asConfig).toEqual({
-      canDragCamera: true,
-      canZoomCamera: true,
-      canDuplicateBlocks: false,
-      canDrag: ECanDrag.ALL,
-      canCreateNewConnections: false,
-      showConnectionArrows: true,
-      scaleFontSize: 1,
-      useBezierConnections: true,
-      bezierConnectionDirection: "horizontal",
-      useBlocksAnchors: true,
-      connectivityComponentOnClickRaise: true,
-      showConnectionLabels: false,
-      blockComponents: {},
-    });
+    expect(store.asConfig).toEqual(DefaultSettings);
   });
 
   it("Should get config via key", () => {

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -35,6 +35,11 @@ export type TGraphSettingsConfig<Block extends TBlock = TBlock, Connection exten
   /** Controls which components can be dragged */
   canDrag?: ECanDrag;
   /**
+   * Minimum distance in pixels the mouse must move before a drag operation starts.
+   * Helps prevent accidental drags during clicks. Default: 3
+   */
+  dragThreshold?: number;
+  /**
    * Controls if connections can be created via anchors
    * If this connection is enabled, then anchors are not draggable and connection creation is handled by ConnectionLayer.
    * */
@@ -51,11 +56,12 @@ export type TGraphSettingsConfig<Block extends TBlock = TBlock, Connection exten
   background?: typeof Component;
 };
 
-const getInitState: TGraphSettingsConfig = {
+export const DefaultSettings: TGraphSettingsConfig = {
   canDragCamera: true,
   canZoomCamera: true,
   canDuplicateBlocks: false,
   canDrag: ECanDrag.ALL,
+  dragThreshold: 5,
   canCreateNewConnections: false,
   showConnectionArrows: true,
   scaleFontSize: 1,
@@ -68,7 +74,7 @@ const getInitState: TGraphSettingsConfig = {
 };
 
 export class GraphEditorSettings {
-  public $settings = signal(getInitState);
+  public $settings = signal(DefaultSettings);
 
   public $blockComponents = computed(() => {
     return this.$settings.value.blockComponents;
@@ -130,6 +136,13 @@ export class GraphEditorSettings {
     return ECanDrag.ALL;
   });
 
+  /**
+   * Drag threshold in pixels. Default: 3
+   */
+  public $dragThreshold = computed((): number => {
+    return this.$settings.value.dragThreshold ?? 3;
+  });
+
   public toJSON() {
     return cloneDeep(this.$settings.toJSON());
   }
@@ -139,6 +152,6 @@ export class GraphEditorSettings {
   }
 
   public reset() {
-    this.setupSettings(getInitState);
+    this.setupSettings(DefaultSettings);
   }
 }


### PR DESCRIPTION
TLDR; 
Instead of preventDefault of event, stopPropagation.
Add threshold param to dragListener,  in order to prevent small drag on click by block 
 