### PR TITLE
fix(GraphPlayground): skip editor updates for multi-block selections

### DIFF
--- a/src/stories/Playground/Editor/index.tsx
+++ b/src/stories/Playground/Editor/index.tsx
@@ -63,7 +63,7 @@ export const ConfigEditor = React.forwardRef(function ConfigEditor(
       });
     },
     updateBlocks: (blocks: TBlock[]) => {
-      if (!monacoRef.current) {
+      if (!monacoRef.current || blocks.length > 1) {
         return;
       }
       const model = monacoRef.current.getModel();


### PR DESCRIPTION
## Problem
freezes when selecting 10 000 blocks

## Why it happens
`findBlockPositionsMonaco` performs document search for each block

## Solution
skip editor updates when updating multiple blocks editor highlighting only works for single selections