### PR TITLE
fix(GraphBlockAnchor): prevent race condition error in component

### DIFF
--- a/src/react-components/Anchor.tsx
+++ b/src/react-components/Anchor.tsx
@@ -38,7 +38,8 @@ export function GraphBlockAnchor({
 
   useEffect(() => {
     if (anchorContainerRef.current) {
-      const hoverScale = anchorState.getViewComponent().getHoverFactor();
+      const viewComponent = anchorState?.getViewComponent();
+      const hoverScale = viewComponent?.getHoverFactor();
       if (hoverScale !== undefined) {
         anchorContainerRef.current.style.setProperty("--graph-block-anchor-hover-scale", hoverScale.toString());
       }


### PR DESCRIPTION
Fix race condition when accessing view component before Canvas initialization

Problem:
- When creating new endpoints, React component renders and useEffect executes
  before Canvas layer creates and registers the view component via setViewComponent()
- This caused "Cannot read properties of undefined (reading 'getHoverFactor')" error

Solution:
- Add optional chaining to anchorState?.getViewComponent() and viewComponent?.getHoverFactor()
- This safely handles the case when view component is not yet registered

The fix ensures the component gracefully handles the async initialization timing
between React rendering and Canvas component registration.