### PR TITLE
fix: disable dragging by default

### DIFF
--- a/src/store/settings.test.ts
+++ b/src/store/settings.test.ts
@@ -29,8 +29,8 @@ describe("Settings store", () => {
 
   describe("$canDrag computed with backward compatibility", () => {
     describe("new setting (canDrag)", () => {
-      it("should default to ALL", () => {
-        expect(store.$canDrag.value).toBe(ECanDrag.ALL);
+      it("should default to NONE", () => {
+        expect(store.$canDrag.value).toBe(ECanDrag.NONE);
       });
 
       it("should use ALL when explicitly set", () => {

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -60,7 +60,7 @@ export const DefaultSettings: TGraphSettingsConfig = {
   canDragCamera: true,
   canZoomCamera: true,
   canDuplicateBlocks: false,
-  canDrag: ECanDrag.ALL,
+  canDrag: ECanDrag.NONE,
   dragThreshold: 5,
   canCreateNewConnections: false,
   showConnectionArrows: true,


### PR DESCRIPTION
In previous release we change default value of the setting `canDrag` to   ECanDrag.ALL. It was a mistake. So in this PR we change default to ECanDrag.NONE