### PR TITLE
feat: add bahaviour on press shift on SelectionLayer

### DIFF
--- a/src/components/canvas/layers/selectionLayer/SelectionLayer.ts
+++ b/src/components/canvas/layers/selectionLayer/SelectionLayer.ts
@@ -122,7 +122,7 @@ export class SelectionLayer extends Layer<
     this.selectionEndWorld = { x: worldX, y: worldY };
   };
 
-  private endSelectionRender = (_event: MouseEvent) => {
+  private endSelectionRender = (event: MouseEvent) => {
     if (!this.selectionStartWorld || !this.selectionEndWorld) {
       return;
     }
@@ -146,7 +146,7 @@ export class SelectionLayer extends Layer<
       this.selectionEndWorld.y
     );
 
-    this.applySelectedArea(worldRect[0], worldRect[1], worldRect[2], worldRect[3]);
+    this.applySelectedArea(worldRect[0], worldRect[1], worldRect[2], worldRect[3], event.shiftKey);
 
     // Clear selection
     this.selectionStartWorld = null;
@@ -154,11 +154,16 @@ export class SelectionLayer extends Layer<
     this.performRender();
   };
 
-  private applySelectedArea(x: number, y: number, w: number, h: number): void {
+  private applySelectedArea(x: number, y: number, w: number, h: number, shiftPressed: boolean): void {
     const selectableEntityTypes = this.context.graph.$graphConstants.value.selectionLayer.SELECTABLE_ENTITY_TYPES;
-    const strategy = this.context.graph.$graphConstants.value.selectionLayer.STRATEGY || ESelectionStrategy.REPLACE;
+    const shiftStrategy = this.context.graph.$graphConstants.value.selectionLayer.SHIFT_STRATEGY;
+    const strategy =
+      shiftPressed && shiftStrategy ? shiftStrategy : this.context.graph.$graphConstants.value.selectionLayer.STRATEGY;
 
     const elements = this.context.graph.getElementsOverRect({ x, y, width: w, height: h }, selectableEntityTypes);
-    this.context.graph.rootStore.selectionService.selectRelatedElements(elements, strategy);
+    this.context.graph.rootStore.selectionService.selectRelatedElements(
+      elements,
+      strategy || ESelectionStrategy.REPLACE
+    );
   }
 }

--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -145,6 +145,19 @@ export type TGraphConstants = {
      * @default ESelectionStrategy.REPLACE
      */
     STRATEGY?: ESelectionStrategy;
+
+    /**
+     * Selection strategy that determines how newly selected entities interact with existing selection when Shift key is pressed.
+     *
+     * Available strategies:
+     * - **`REPLACE`** - New selection replaces the current selection entirely
+     * - **`APPEND`** - New selection is added to the current selection
+     * - **`SUBTRACT`** - New selection is removed from the current selection
+     * - **`TOGGLE`** - New selection toggles the selection state of entities
+     *
+     * @default ESelectionStrategy.APPEND
+     */
+    SHIFT_STRATEGY?: ESelectionStrategy;
   };
 
   system: {


### PR DESCRIPTION
On press Shift, SelectionLayer should use stratery from constant selectionLayer.SHIFT_STRATEGY. 
By default SHIFT_STRATEGY = STRATEGY