### PR TITLE
fix(Group): add resolver for groups selection bucket

### DIFF
--- a/src/components/canvas/groups/Group.ts
+++ b/src/components/canvas/groups/Group.ts
@@ -226,6 +226,7 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
         selected,
       });
     });
+    this.groupState.setViewComponent(this);
     return this.subscribeSignal(this.groupState.$state, (group) => {
       if (group) {
         this.setState({
@@ -235,6 +236,11 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
         this.updateHitBox(this.getRect(group.rect));
       }
     });
+  }
+
+  protected unmount(): void {
+    this.groupState.setViewComponent(undefined);
+    super.unmount();
   }
 
   protected updateHitBox(rect: TRect) {

--- a/src/store/group/Group.ts
+++ b/src/store/group/Group.ts
@@ -44,7 +44,7 @@ export class GroupState {
     this.$state.value = state;
   }
 
-  public setViewComponent(component: Group) {
+  public setViewComponent(component: Group | undefined) {
     this.$viewComponent.value = component;
   }
 

--- a/src/store/group/Group.ts
+++ b/src/store/group/Group.ts
@@ -27,6 +27,8 @@ export class GroupState {
     component: Group,
   });
 
+  public readonly $viewComponent = signal<Group | undefined>(undefined);
+
   /**
    * When true, the group's rect should not be auto-updated based on contained blocks.
    * Used during Shift+drag to keep the group visually stable.
@@ -40,6 +42,14 @@ export class GroupState {
     private readonly groupSelectionBucket: ISelectionBucket<string | number>
   ) {
     this.$state.value = state;
+  }
+
+  public setViewComponent(component: Group) {
+    this.$viewComponent.value = component;
+  }
+
+  public getViewComponent() {
+    return this.$viewComponent.value;
   }
 
   /**

--- a/src/store/group/GroupsList.ts
+++ b/src/store/group/GroupsList.ts
@@ -36,6 +36,12 @@ export class GroupsListStore {
     },
     (element) => {
       return element instanceof Group;
+    },
+    (ids) => {
+      return this.getGroupStates(ids)
+        .filter((value): value is GroupState => Boolean(value))
+        .map((group) => group.getViewComponent())
+        .filter((value): value is Group => Boolean(value));
     }
   );
 


### PR DESCRIPTION
## Summary by Sourcery

Track and expose the live view component associated with each group state and ensure group selection operates on mounted Group view instances.

Enhancements:
- Add a dedicated signal and accessors on GroupState to store the associated Group view component instance.
- Register and clear the Group view component on mount/unmount of the Group canvas component.
- Extend the GroupsListStore selection bucket resolver to map group IDs to their mounted Group view components.