### PR TITLE
[WIP]fix: stop RAF loop when no updates are pending

### DIFF
--- a/src/lib/Scheduler.ts
+++ b/src/lib/Scheduler.ts
@@ -18,9 +18,10 @@ export enum ESchedulerPriority {
 }
 export class GlobalScheduler {
   private schedulers: [IScheduler[], IScheduler[], IScheduler[], IScheduler[], IScheduler[]];
-  private _cAFID: number;
+  private _cAFID: number | undefined;
   private toRemove: Array<[IScheduler, ESchedulerPriority]> = [];
   private visibilityChangeHandler: (() => void) | null = null;
+  private needsUpdate = false;
 
   constructor() {
     this.tick = this.tick.bind(this);
@@ -50,9 +51,9 @@ export class GlobalScheduler {
    */
   private handleVisibilityChange(): void {
     // Only update if page becomes visible and scheduler is running
-    if (!document.hidden && this._cAFID) {
+    if (!document.hidden) {
       // Perform immediate update when tab becomes visible
-      this.performUpdate();
+      this.requestUpdate();
     }
   }
 
@@ -72,6 +73,7 @@ export class GlobalScheduler {
 
   public addScheduler(scheduler: IScheduler, index = ESchedulerPriority.MEDIUM) {
     this.schedulers[index].push(scheduler);
+    this.requestUpdate();
     return () => this.removeScheduler(scheduler, index);
   }
 
@@ -99,9 +101,19 @@ export class GlobalScheduler {
     this.cleanupVisibilityListener();
   }
 
+  public requestUpdate() {
+    this.needsUpdate = true;
+    this.start();
+  }
+
   public tick() {
-    this.performUpdate();
-    this._cAFID = rAF(this.tick);
+    if (this.needsUpdate) {
+      this.needsUpdate = false;
+      this.performUpdate();
+      this._cAFID = rAF(this.tick);
+    } else {
+      this._cAFID = undefined;
+    }
   }
 
   public performUpdate() {
@@ -164,6 +176,7 @@ export class Scheduler {
 
   public scheduleUpdate() {
     this.sheduled = true;
+    globalScheduler.requestUpdate();
   }
 
   public performUpdate() {

--- a/src/utils/utils/schedule.ts
+++ b/src/utils/utils/schedule.ts
@@ -29,7 +29,11 @@ export const schedule = (fn: Function, options: TScheduleOptions) => {
         if (once) {
           isRemoved = true;
           scheduler.removeScheduler(debounceScheduler, priority);
+        } else {
+          scheduler.requestUpdate();
         }
+      } else {
+        scheduler.requestUpdate();
       }
     },
   };
@@ -89,6 +93,8 @@ export const debounce = <T extends (...args: Parameters<T>) => void>(
         if (currentRemoveScheduler) {
           currentRemoveScheduler();
         }
+      } else {
+        scheduler.requestUpdate();
       }
     },
   };
@@ -173,6 +179,8 @@ export const throttle = <T extends (...args: Parameters<T>) => void>(
         if (currentRemoveScheduler) {
           currentRemoveScheduler();
         }
+      } else {
+        scheduler.requestUpdate();
       }
     },
   };


### PR DESCRIPTION
## Summary

- GlobalScheduler's `tick()` was running a continuous `requestAnimationFrame` loop even when the graph was completely idle, causing unnecessary CPU/GPU usage
- Introduced a `needsUpdate` flag and `requestUpdate()` method so the RAF loop only runs when there is actual work to process
- All update entry points (`scheduleUpdate`, `addScheduler`, `visibilitychange`) now call `requestUpdate()` to start/resume the loop on demand
- `schedule`/`debounce`/`throttle` utilities call `requestUpdate()` each frame while waiting for their `frameInterval`, keeping the loop alive until done

## Motivation

Users reported high CPU/GPU usage in the new graph interface — GPU jumping from 4% to 36%, CPU from 9% to 31%. Performance tracing showed the main cause: `tick()` was firing ~120 RAF calls/sec continuously, even in idle, triggering
Layerize, GPUTask, and style recalculations every frame with no actual updates.

## Results (performance trace comparison, same interaction scenario)

| Metric           | Before   | After    | Change |
|------------------|----------|----------|--------|
| CPU idle         | 4.2%     | 1.9%     | -55%   |
| RAF calls        | 1291     | 537      | -58%   |
| Layerize         | 731ms    | 399ms    | -45%   |
| GPUTask          | 466ms    | 244ms    | -48%   |
| UpdateLayoutTree | 223ms    | 133ms    | -40%   |
| FunctionCall     | 1148ms   | 621ms    | -46%   |

## Summary by Sourcery

Ensure the global scheduler’s animation loop only runs when updates are pending to reduce idle CPU/GPU usage.

Bug Fixes:
- Stop the global scheduler’s requestAnimationFrame loop from running continuously when there are no pending updates.

Enhancements:
- Introduce a needsUpdate flag and requestUpdate entry point so the scheduler starts or resumes the animation loop on demand.
- Trigger scheduler updates from scheduler registration, per-scheduler scheduleUpdate calls, and schedule/debounce/throttle utilities while work is pending.
- Adjust visibility-change behavior so resuming a visible tab requests an update instead of forcing continuous ticking.