### PR TITLE
feat(camera): add PAN_SPEED to configure camera pan speed

### DIFF
--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -219,6 +219,13 @@ export type TGraphConstants = {
      * @default 1
      */
     PINCH_ZOOM_SPEED: number;
+    /**
+     * Multiplier for camera pan speed applied to both mouse drag and trackpad swipe gestures.
+     * Does not affect auto-panning (see AUTO_PAN_SPEED) or zoom speed (see SPEED, PINCH_ZOOM_SPEED).
+     *
+     * @default 1
+     */
+    PAN_SPEED: number;
   };
 
   block: {
@@ -273,6 +280,7 @@ export const initGraphConstants: TGraphConstants = {
     AUTO_PAN_SPEED: 5,
     MOUSE_WHEEL_BEHAVIOR: "zoom",
     PINCH_ZOOM_SPEED: 1,
+    PAN_SPEED: 1,
   },
   block: {
     WIDTH_MIN: 16 * 10,

--- a/src/plugins/cssVariables/constants.ts
+++ b/src/plugins/cssVariables/constants.ts
@@ -115,6 +115,7 @@ export const CSS_VARIABLE_MAPPINGS: CSSVariableMappings = [
   // Camera constants
   { cssVariable: "--graph-camera-speed", graphPath: "camera.SPEED", typeConverter: CSSVariableType.FLOAT },
   { cssVariable: "--graph-camera-step", graphPath: "camera.STEP", typeConverter: CSSVariableType.FLOAT },
+  { cssVariable: "--graph-camera-pan-speed", graphPath: "camera.PAN_SPEED", typeConverter: CSSVariableType.FLOAT },
 
   // Text constants
   {

--- a/src/services/camera/Camera.ts
+++ b/src/services/camera/Camera.ts
@@ -210,7 +210,11 @@ export class Camera extends EventedComponent<TCameraProps, TComponentState, TGra
     if (!this.lastDragEvent) {
       return;
     }
-    this.camera.move(event.pageX - this.lastDragEvent.pageX, event.pageY - this.lastDragEvent.pageY);
+    const panSpeed = this.context.constants.camera.PAN_SPEED;
+    this.camera.move(
+      (event.pageX - this.lastDragEvent.pageX) * panSpeed,
+      (event.pageY - this.lastDragEvent.pageY) * panSpeed
+    );
     this.lastDragEvent = event;
   }
 
@@ -223,10 +227,11 @@ export class Camera extends EventedComponent<TCameraProps, TComponentState, TGra
    */
   private handleTrackpadMove(event: WheelEvent): void {
     const hasWrongHorizontalScroll = event.shiftKey && Math.abs(event.deltaY) > 0.001;
+    const panSpeed = this.context.constants.camera.PAN_SPEED;
 
     this.moveWithEdges(
-      hasWrongHorizontalScroll ? -event.deltaY : -event.deltaX,
-      hasWrongHorizontalScroll ? -event.deltaX : -event.deltaY
+      (hasWrongHorizontalScroll ? -event.deltaY : -event.deltaX) * panSpeed,
+      (hasWrongHorizontalScroll ? -event.deltaX : -event.deltaY) * panSpeed
     );
   }
 

--- a/src/stories/api/zoomSpeed/zoomSpeed.stories.tsx
+++ b/src/stories/api/zoomSpeed/zoomSpeed.stories.tsx
@@ -14,10 +14,11 @@ const config = generatePrettyBlocks({ layersCount: 10, connectionsPerLayer: 10, 
 const GraphApp = () => {
   const [speed, setSpeed] = useState("1");
   const [step, setStep] = useState("0.008");
+  const [panSpeed, setPanSpeed] = useState("1");
 
   const graphRef = useRef<Graph | undefined>(undefined);
 
-  const onClick: ButtonButtonProps["onClick"] = useCallback(() => {
+  const onApplyZoom: ButtonButtonProps["onClick"] = useCallback(() => {
     graphRef.current.setConstants({
       camera: {
         SPEED: Number(speed),
@@ -26,14 +27,30 @@ const GraphApp = () => {
     });
   }, [speed, step]);
 
+  const onApplyPan: ButtonButtonProps["onClick"] = useCallback(() => {
+    graphRef.current.setConstants({
+      camera: {
+        PAN_SPEED: Number(panSpeed),
+      },
+    });
+  }, [panSpeed]);
+
   return (
     <ThemeProvider theme={"light"}>
-      <Flex direction={"column"} width={320} gap={2} style={{ marginBottom: "10px" }}>
-        <TextInput type="number" label="speed" value={speed} onUpdate={setSpeed} />
-        <TextInput type="number" label="step" value={step} onUpdate={setStep} />
-        <Button onClick={onClick} view="action">
-          apply zoom config
-        </Button>
+      <Flex direction={"row"} gap={6} style={{ marginBottom: "10px" }}>
+        <Flex direction={"column"} width={320} gap={2}>
+          <TextInput type="number" label="speed" value={speed} onUpdate={setSpeed} />
+          <TextInput type="number" label="step" value={step} onUpdate={setStep} />
+          <Button onClick={onApplyZoom} view="action">
+            apply zoom config
+          </Button>
+        </Flex>
+        <Flex direction={"column"} width={320} gap={2}>
+          <TextInput type="number" label="pan speed" value={panSpeed} onUpdate={setPanSpeed} />
+          <Button onClick={onApplyPan} view="action">
+            apply pan config
+          </Button>
+        </Flex>
       </Flex>
       <GraphComponentStory graphRef={graphRef} config={config}></GraphComponentStory>
     </ThemeProvider>


### PR DESCRIPTION
## Summary

- Adds `PAN_SPEED: number` to `TGraphConstants.camera` (default `1`, fully backwards-compatible)
- Applies the multiplier in both pan paths: mouse drag (`onDragUpdate`) and trackpad swipe (`handleTrackpadMove`)
- Exposes `--graph-camera-pan-speed` CSS variable alongside the existing `--graph-camera-speed`
- Adds pan speed control to the `Api/zoomSpeed` Storybook story for manual testing

`AUTO_PAN_SPEED` is intentionally left unchanged — it controls edge-drag auto-panning and has separate semantics.

## Usage

```ts
graph.setConstants({ camera: { PAN_SPEED: 2 } }); // 2× faster pan
```

Or via CSS variables plugin:
```css
:root { --graph-camera-pan-speed: 2; }
```

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test` — 291 passed, 0 failures
- [ ] Manual: open `Api/zoomSpeed` story, change pan speed slider, verify drag and trackpad swipe scale accordingly while zoom is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable camera pan speed and expose it via API, CSS variables, and Storybook controls.

New Features:
- Introduce PAN_SPEED camera constant to control pan gesture speed independently of zoom.
- Expose camera pan speed as a CSS variable for configuration via the CSS variables plugin.
- Add Storybook controls to adjust and apply pan speed separately from zoom speed in the zoomSpeed story.