### PR TITLE
feat: coalesced blocks-geometry-change on position updates

### DIFF
--- a/e2e/tests/block/block-geometry-batching.spec.ts
+++ b/e2e/tests/block/block-geometry-batching.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from "@playwright/test";
+
+import { GraphPageObject } from "../../page-objects/GraphPageObject";
+
+const TWO_BLOCKS = [
+  {
+    id: "block-1",
+    is: "Block",
+    x: 300,
+    y: 200,
+    width: 200,
+    height: 100,
+    name: "Block 1",
+    anchors: [],
+    selected: false,
+  },
+  {
+    id: "block-2",
+    is: "Block",
+    x: 600,
+    y: 300,
+    width: 200,
+    height: 100,
+    name: "Block 2",
+    anchors: [],
+    selected: false,
+  },
+];
+
+const DRAG_SETTINGS = {
+  canDrag: "all" as const,
+  dragThreshold: 0,
+};
+
+test.describe("block-change + coalesced blocks-geometry-change", () => {
+  test("single-block drag emits both block-change and fewer blocks-geometry-change events", async ({ page }) => {
+    const graphPO = new GraphPageObject(page);
+    await graphPO.initialize({
+      blocks: TWO_BLOCKS,
+      connections: [],
+      settings: DRAG_SETTINGS,
+    });
+
+    const readBlockChange = await graphPO.collectGraphEventDetails<{ block: { id: string } }>("block-change");
+    const readGeom = await graphPO.collectGraphEventDetails<{ blocks: { id: string }[] }>("blocks-geometry-change");
+
+    const nBlock0 = (await readBlockChange()).length;
+    const nGeom0 = (await readGeom()).length;
+
+    const block1 = graphPO.getBlockCOM("block-1");
+    await block1.click();
+    await block1.dragTo({ x: 420, y: 260 });
+
+    const dBlock = (await readBlockChange()).length - nBlock0;
+    const dGeom = (await readGeom()).length - nGeom0;
+
+    expect(dBlock).toBeGreaterThan(0);
+    expect(dGeom).toBeGreaterThan(0);
+    expect(dGeom).toBeLessThanOrEqual(dBlock);
+  });
+
+  test("multi-block drag: geometry batches include both ids; geometry fires less often than block-change", async ({
+    page,
+  }) => {
+    const graphPO = new GraphPageObject(page);
+    await graphPO.initialize({
+      blocks: TWO_BLOCKS,
+      connections: [],
+      settings: DRAG_SETTINGS,
+    });
+
+    const readBlockChange = await graphPO.collectGraphEventDetails("block-change");
+    const readGeom = await graphPO.collectGraphEventDetails<{ blocks: { id: string; x: number; y: number; width: number; height: number }[] }>(
+      "blocks-geometry-change"
+    );
+
+    const nBlock0 = (await readBlockChange()).length;
+    const nGeom0 = (await readGeom()).length;
+
+    const block1 = graphPO.getBlockCOM("block-1");
+    const block2 = graphPO.getBlockCOM("block-2");
+    await block1.click();
+    await block2.click({ ctrl: true });
+    await block1.dragTo({ x: 500, y: 350 });
+
+    const dBlock = (await readBlockChange()).length - nBlock0;
+    const geomEvents = await readGeom();
+    const newGeom = geomEvents.slice(nGeom0);
+
+    expect(dBlock).toBeGreaterThan(0);
+    expect(newGeom.length).toBeGreaterThan(0);
+    expect(newGeom.length).toBeLessThan(dBlock);
+
+    const last = newGeom[newGeom.length - 1];
+    expect(last.blocks.map((b) => b.id).sort()).toEqual(["block-1", "block-2"]);
+
+    for (const b of last.blocks) {
+      expect(Object.keys(b).sort()).toEqual(["height", "id", "width", "x", "y"]);
+    }
+  });
+
+  test("group drag moves two blocks: last geometry batch lists both ids", async ({ page }) => {
+    const graphPO = new GraphPageObject(page);
+    const GROUP_PAD = 20;
+    const blocks = [
+      {
+        id: "block-1",
+        is: "Block",
+        x: 100,
+        y: 100,
+        width: 200,
+        height: 100,
+        name: "Block 1",
+        anchors: [],
+        selected: false,
+        group: "group-1",
+      },
+      {
+        id: "block-2",
+        is: "Block",
+        x: 100,
+        y: 280,
+        width: 200,
+        height: 100,
+        name: "Block 2",
+        anchors: [],
+        selected: false,
+        group: "group-1",
+      },
+    ];
+
+    await graphPO.initialize({
+      blocks,
+      connections: [],
+      settings: {
+        ...DRAG_SETTINGS,
+        canDragCamera: false,
+      },
+    });
+
+    await graphPO.page.evaluate((pad: number) => {
+      const { BlockGroups, Group } = (window as any).GraphModule;
+      const graph = window.graph;
+
+      const GroupingLayer = BlockGroups.withBlockGrouping({
+        groupingFn: (blockStates: any[]) => {
+          const result: Record<string, any[]> = {};
+          blockStates.forEach((blockState) => {
+            const groupId = blockState.$state.value.group;
+            if (groupId) {
+              if (!result[groupId]) result[groupId] = [];
+              result[groupId].push(blockState);
+            }
+          });
+          return result;
+        },
+        mapToGroups: (key: string, { rect }: { rect: { x: number; y: number; width: number; height: number } }) => ({
+          id: key,
+          rect: {
+            x: rect.x - pad,
+            y: rect.y - pad,
+            width: rect.width + pad * 2,
+            height: rect.height + pad * 2,
+          },
+          component: Group,
+        }),
+      });
+
+      graph.addLayer(GroupingLayer, { draggable: true, updateBlocksOnDrag: true });
+    }, GROUP_PAD);
+
+    await graphPO.waitForFrames(5);
+
+    const readGeom = await graphPO.collectGraphEventDetails<{ blocks: { id: string }[] }>("blocks-geometry-change");
+
+    const nGeom0 = (await readGeom()).length;
+
+    const groupRect = await graphPO.page.evaluate(() => {
+      return window.graph.rootStore.groupsList.getGroupState("group-1")!.$state.value.rect;
+    });
+
+    const cx = groupRect.x + groupRect.width / 2;
+    const cy = groupRect.y + 12;
+
+    await graphPO.click(cx, cy);
+    await graphPO.dragTo(cx, cy, cx + 80, cy + 50, { waitFrames: 25 });
+
+    const newGeom = (await readGeom()).slice(nGeom0);
+    expect(newGeom.length).toBeGreaterThan(0);
+
+    const last = newGeom[newGeom.length - 1];
+    expect(last.blocks.map((b) => b.id).sort()).toEqual(["block-1", "block-2"]);
+  });
+
+  test("block-change preventDefault skips position update and blocks-geometry-change", async ({ page }) => {
+    const graphPO = new GraphPageObject(page);
+    await graphPO.initialize({
+      blocks: TWO_BLOCKS,
+      connections: [],
+      settings: DRAG_SETTINGS,
+    });
+
+    await page.evaluate(() => {
+      window.graph.on("block-change", (event: Event) => {
+        event.preventDefault();
+      });
+    });
+
+    const readGeom = await graphPO.collectGraphEventDetails("blocks-geometry-change");
+    const nGeom0 = (await readGeom()).length;
+
+    const block1 = graphPO.getBlockCOM("block-1");
+    const initial = await block1.getGeometry();
+    await block1.click();
+    await block1.dragTo({ x: 500, y: 350 });
+
+    const final = await block1.getGeometry();
+    expect(final.x).toBe(initial.x);
+    expect(final.y).toBe(initial.y);
+    expect((await readGeom()).length - nGeom0).toBe(0);
+  });
+});

--- a/e2e/tests/block/block-geometry-batching.spec.ts
+++ b/e2e/tests/block/block-geometry-batching.spec.ts
@@ -59,6 +59,36 @@ test.describe("block-change + coalesced blocks-geometry-change", () => {
     expect(dGeom).toBeLessThanOrEqual(dBlock);
   });
 
+  test("after drag end, blocks-geometry-change follows last block-change (rAF or flush)", async ({ page }) => {
+    const graphPO = new GraphPageObject(page);
+    await graphPO.initialize({
+      blocks: TWO_BLOCKS,
+      connections: [],
+      settings: DRAG_SETTINGS,
+    });
+
+    await page.evaluate(() => {
+      const order: string[] = [];
+      (window as unknown as { __geometryFlushOrder: string[] }).__geometryFlushOrder = order;
+      window.graph.on("block-change", () => {
+        order.push("block-change");
+      });
+      window.graph.on("blocks-geometry-change", () => {
+        order.push("blocks-geometry-change");
+      });
+    });
+
+    const block1 = graphPO.getBlockCOM("block-1");
+    await block1.click();
+    await block1.dragTo({ x: 420, y: 260 });
+
+    const order = await page.evaluate(() => (window as unknown as { __geometryFlushOrder: string[] }).__geometryFlushOrder);
+
+    const lastBlockIdx = order.lastIndexOf("block-change");
+    expect(lastBlockIdx).toBeGreaterThan(-1);
+    expect(order.slice(lastBlockIdx + 1).includes("blocks-geometry-change")).toBe(true);
+  });
+
   test("multi-block drag: geometry batches include both ids; geometry fires less often than block-change", async ({
     page,
   }) => {

--- a/src/components/canvas/groups/BlockGroups.ts
+++ b/src/components/canvas/groups/BlockGroups.ts
@@ -214,7 +214,7 @@ export class BlockGroups<P extends BlockGroupsProps = BlockGroupsProps> extends 
   public updateBlocks = (groupId: TGroupId, { deltaX, deltaY }: { deltaX: number; deltaY: number }) => {
     if (this.props.updateBlocksOnDrag) {
       const blocks = this.$groupsBlocksMap.value[groupId];
-      if (blocks) {
+      if (blocks?.length) {
         blocks.forEach((block) => {
           block.updateXY(block.x + deltaX, block.y + deltaY, true);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type { AnchorState } from "./store/anchor/Anchor";
 export type { TPort, TPortId } from "./store/connection/port/Port";
 export { createAnchorPortId, createBlockPointPortId, createPortId } from "./store/connection/port/utils";
 export { ECanChangeBlockGeometry, ECanDrag } from "./store/settings";
+export type { TBlockGeometrySnapshot } from "./store/block/BlocksList";
 export { type TMeasureTextOptions, type TWrapText } from "./utils/functions/text";
 export { ESchedulerPriority } from "./lib/Scheduler";
 export { debounce, throttle, schedule } from "./utils/functions";

--- a/src/plugins/minimap/layer.ts
+++ b/src/plugins/minimap/layer.ts
@@ -68,12 +68,13 @@ export class MiniMapLayer extends Layer<MiniMapLayerProps> {
     this.onGraphEvent("camera-change", () => this.performRender());
     this.onGraphEvent("colors-changed", () => this.performRender());
 
-    // block-change recalculates coords: blocks may change size/position
-    // without the usableRect bounding box itself changing.
-    this.onGraphEvent("block-change", () => {
+    // block-change / batched geometry during drag — recalculate coords when blocks move
+    const onBlocksMoved = () => {
       this.calculateViewPortCoords();
       this.performRender();
-    });
+    };
+    this.onGraphEvent("block-change", onBlocksMoved);
+    this.onGraphEvent("blocks-geometry-change", onBlocksMoved);
 
     if (this.canvas) {
       this.onCanvasEvent("mousedown", this.handleMouseDownEvent);

--- a/src/react-components/events.ts
+++ b/src/react-components/events.ts
@@ -19,6 +19,10 @@ export type TGraphEventCallbacks = {
     event: UnwrapGraphEvents<"block-anchor-selection-change">
   ) => void;
   onBlockChange: (data: UnwrapGraphEventsDetail<"block-change">, event: UnwrapGraphEvents<"block-change">) => void;
+  onBlocksGeometryChange: (
+    data: UnwrapGraphEventsDetail<"blocks-geometry-change">,
+    event: UnwrapGraphEvents<"blocks-geometry-change">
+  ) => void;
   onConnectionSelectionChange: (
     data: UnwrapGraphEventsDetail<"connection-selection-change">,
     event: UnwrapGraphEvents<"connection-selection-change">
@@ -39,6 +43,7 @@ export const GraphCallbacksMap = {
   onBlockSelectionChange: "blocks-selection-change",
   onBlockAnchorSelectionChange: "block-anchor-selection-change",
   onBlockChange: "block-change",
+  onBlocksGeometryChange: "blocks-geometry-change",
   onConnectionSelectionChange: "connection-selection-change",
   onStateChanged: "state-change",
 } as const satisfies Record<keyof TGraphEventCallbacks, keyof GraphEventsDefinitions>;

--- a/src/services/drag/DragService.ts
+++ b/src/services/drag/DragService.ts
@@ -236,7 +236,6 @@ export class DragService {
       components: this.dragComponents,
     };
 
-    // Notify all components about drag update
     this.dragComponents.forEach((component) => {
       component.handleDrag(diff, context);
     });
@@ -265,6 +264,7 @@ export class DragService {
       });
     }
 
+    this.graph.rootStore.blocksList.flushBatchedBlocksGeometryEmit();
     this.cleanup();
   };
 

--- a/src/store/block/Block.ts
+++ b/src/store/block/Block.ts
@@ -262,4 +262,15 @@ export class BlockState<T extends TBlock = TBlock> {
       selected: this.$selected.value,
     });
   }
+
+  /**
+   * Cheap snapshot for graph events (e.g. `block-change`): one object spread, no deep clone.
+   * Nested values (`anchors`, `meta`, `settings`, …) are shared with the live store — treat as read-only.
+   */
+  public asTBlockShallow(): TBlock {
+    return {
+      ...this.$rawState.value,
+      selected: this.$selected.value,
+    };
+  }
 }

--- a/src/store/block/Block.ts
+++ b/src/store/block/Block.ts
@@ -267,7 +267,7 @@ export class BlockState<T extends TBlock = TBlock> {
    * Cheap snapshot for graph events (e.g. `block-change`): one object spread, no deep clone.
    * Nested values (`anchors`, `meta`, `settings`, …) are shared with the live store — treat as read-only.
    */
-  public asTBlockShallow(): TBlock {
+  public asTBlockShallow(): Readonly<TBlock> {
     return {
       ...this.$rawState.value,
       selected: this.$selected.value,

--- a/src/store/block/BlocksList.ts
+++ b/src/store/block/BlocksList.ts
@@ -13,6 +13,15 @@ import { RootStore } from "../index";
 
 import { BlockState, TBlockId } from "./Block";
 
+/** Lightweight block bounds for the `blocks-geometry-change` event. */
+export type TBlockGeometrySnapshot = {
+  id: TBlockId;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 declare module "../../graphEvents" {
   interface GraphEventsDefinitions {
     /**
@@ -38,14 +47,25 @@ declare module "../../graphEvents" {
     ) => void;
 
     /**
-     * Emited when block changes.
+     * Emited when block position is about to update via {@link BlockListStore.updatePosition}.
      *
-     * Preventing the event will prevent block change.
+     * `detail.block` is a shallow snapshot (see {@link BlockState.asTBlockShallow}); do not mutate nested fields.
+     * Preventing the event skips the store update and excludes the block from the next `blocks-geometry-change` batch.
      */
     "block-change": (
       event: CustomEvent<{
         /** Changed block */
         block: TBlock;
+      }>
+    ) => void;
+
+    /**
+     * Coalesced geometry updates after {@link BlockListStore.updatePosition} (at most once per animation frame).
+     * Payload is `{ id, x, y, width, height }` per block only.
+     */
+    "blocks-geometry-change": (
+      event: CustomEvent<{
+        blocks: TBlockGeometrySnapshot[];
       }>
     ) => void;
   }
@@ -58,6 +78,10 @@ export class BlockListStore {
   public $blocksMap = signal<Map<BlockState["id"], BlockState>>(new Map());
 
   public $blocks = signal<BlockState[]>([]);
+
+  private batchedGeometryPending = new Map<BlockState["id"], TBlockGeometrySnapshot>();
+
+  private batchedGeometryRaf: number | null = null;
 
   /**
    * This signal is used to store blocks in reactive state.
@@ -219,9 +243,53 @@ export class BlockListStore {
     if (!blockState) {
       return;
     }
-    this.graph.executеDefaultEventAction("block-change", { block: blockState.asTBlock() }, () => {
+
+    this.graph.executеDefaultEventAction("block-change", { block: blockState.asTBlockShallow() }, () => {
       blockState.updateBlock(nextState);
+      const geometry = blockState.$geometry.value;
+      this.batchedGeometryPending.set(id, { id, ...geometry });
+      this.scheduleBatchedBlocksGeometryFlush();
     });
+  }
+
+  /**
+   * Flushes pending `blocks-geometry-change` immediately (cancels a scheduled rAF if any).
+   * Called when a graph drag ends so the last frame is not lost.
+   */
+  public flushBatchedBlocksGeometryEmit(): void {
+    if (this.batchedGeometryRaf !== null) {
+      cancelAnimationFrame(this.batchedGeometryRaf);
+      this.batchedGeometryRaf = null;
+    }
+    if (this.batchedGeometryPending.size === 0) {
+      return;
+    }
+    const blocks = Array.from(this.batchedGeometryPending.values());
+    this.batchedGeometryPending.clear();
+    this.graph.emit("blocks-geometry-change", { blocks });
+  }
+
+  private scheduleBatchedBlocksGeometryFlush(): void {
+    if (this.batchedGeometryRaf !== null) {
+      return;
+    }
+    this.batchedGeometryRaf = requestAnimationFrame(() => {
+      this.batchedGeometryRaf = null;
+      if (this.batchedGeometryPending.size === 0) {
+        return;
+      }
+      const blocks = Array.from(this.batchedGeometryPending.values());
+      this.batchedGeometryPending.clear();
+      this.graph.emit("blocks-geometry-change", { blocks });
+    });
+  }
+
+  private cancelBatchedBlocksGeometry(): void {
+    if (this.batchedGeometryRaf !== null) {
+      cancelAnimationFrame(this.batchedGeometryRaf);
+      this.batchedGeometryRaf = null;
+    }
+    this.batchedGeometryPending.clear();
   }
 
   protected updateBlocksMap(blocks: Map<BlockState["id"], BlockState> | [BlockState["id"], BlockState][]) {
@@ -393,6 +461,7 @@ export class BlockListStore {
   }
 
   public reset() {
+    this.cancelBatchedBlocksGeometry();
     this.applyBlocksState([]);
   }
 

--- a/src/store/block/BlocksList.ts
+++ b/src/store/block/BlocksList.ts
@@ -26,14 +26,14 @@ declare module "../../graphEvents" {
   interface GraphEventsDefinitions {
     /**
      *
-     * Emited when selection of blocks changes.
+     * Emitted when selection of blocks changes.
      * Preventing the event will prevent selection change.
      *
      */
     "blocks-selection-change": (event: SelectionEvent<TBlockId>) => void;
 
     /**
-     * Emited when selection of block's anchor changes.
+     * Emitted when selection of block's anchor changes.
      * Preventing the event will prevent selection change.
      *
      */
@@ -47,15 +47,15 @@ declare module "../../graphEvents" {
     ) => void;
 
     /**
-     * Emited when block position is about to update via {@link BlockListStore.updatePosition}.
+     * Emitted when block position is about to update via {@link BlockListStore.updatePosition}.
      *
      * `detail.block` is a shallow snapshot (see {@link BlockState.asTBlockShallow}); do not mutate nested fields.
      * Preventing the event skips the store update and excludes the block from the next `blocks-geometry-change` batch.
      */
     "block-change": (
       event: CustomEvent<{
-        /** Changed block */
-        block: TBlock;
+        /** Shallow snapshot; nested fields are shared with the store — read-only. */
+        block: Readonly<TBlock>;
       }>
     ) => void;
 
@@ -257,16 +257,8 @@ export class BlockListStore {
    * Called when a graph drag ends so the last frame is not lost.
    */
   public flushBatchedBlocksGeometryEmit(): void {
-    if (this.batchedGeometryRaf !== null) {
-      cancelAnimationFrame(this.batchedGeometryRaf);
-      this.batchedGeometryRaf = null;
-    }
-    if (this.batchedGeometryPending.size === 0) {
-      return;
-    }
-    const blocks = Array.from(this.batchedGeometryPending.values());
-    this.batchedGeometryPending.clear();
-    this.graph.emit("blocks-geometry-change", { blocks });
+    this.clearGeometryRaf();
+    this.emitPendingBlocksGeometry();
   }
 
   private scheduleBatchedBlocksGeometryFlush(): void {
@@ -275,20 +267,28 @@ export class BlockListStore {
     }
     this.batchedGeometryRaf = requestAnimationFrame(() => {
       this.batchedGeometryRaf = null;
-      if (this.batchedGeometryPending.size === 0) {
-        return;
-      }
-      const blocks = Array.from(this.batchedGeometryPending.values());
-      this.batchedGeometryPending.clear();
-      this.graph.emit("blocks-geometry-change", { blocks });
+      this.emitPendingBlocksGeometry();
     });
   }
 
-  private cancelBatchedBlocksGeometry(): void {
+  private clearGeometryRaf(): void {
     if (this.batchedGeometryRaf !== null) {
       cancelAnimationFrame(this.batchedGeometryRaf);
       this.batchedGeometryRaf = null;
     }
+  }
+
+  private emitPendingBlocksGeometry(): void {
+    if (this.batchedGeometryPending.size === 0) {
+      return;
+    }
+    const blocks = Array.from(this.batchedGeometryPending.values());
+    this.batchedGeometryPending.clear();
+    this.graph.emit("blocks-geometry-change", { blocks });
+  }
+
+  private cancelBatchedBlocksGeometry(): void {
+    this.clearGeometryRaf();
     this.batchedGeometryPending.clear();
   }
 

--- a/src/stories/Playground/GraphPlayground.tsx
+++ b/src/stories/Playground/GraphPlayground.tsx
@@ -158,9 +158,18 @@ export function GraphPLayground() {
     });
   });
 
-  useGraphEvent(graph, "block-change", ({ block }) => {
-    editorRef?.current.updateBlocks([block]);
-    editorRef?.current.scrollTo(block.id);
+  useGraphEvent(graph, "blocks-geometry-change", ({ blocks: geometryBatch }) => {
+    if (!geometryBatch.length) {
+      return;
+    }
+    const fullBlocks = geometryBatch
+      .map((g) => graph.rootStore.blocksList.getBlock(g.id))
+      .filter((b): b is TBlock => b != null);
+    if (!fullBlocks.length) {
+      return;
+    }
+    editorRef?.current?.updateBlocks(fullBlocks);
+    editorRef?.current?.scrollTo(geometryBatch[0].id);
   });
 
   useGraphEvent(graph, "blocks-selection-change", ({ changes }) => {

--- a/src/stories/Playground/GraphPlayground.tsx
+++ b/src/stories/Playground/GraphPlayground.tsx
@@ -164,7 +164,7 @@ export function GraphPLayground() {
     }
     const fullBlocks = geometryBatch
       .map((g) => graph.rootStore.blocksList.getBlock(g.id))
-      .filter((b): b is TBlock => b != null);
+      .filter((b): b is TBlock => b !== undefined);
     if (!fullBlocks.length) {
       return;
     }


### PR DESCRIPTION
## Summary
- Coalesce `blocks-geometry-change` to at most once per animation frame whenever block position updates via `BlockListStore.updatePosition`.
- Keep `block-change` with a shallow block snapshot (`asTBlockShallow`) so `preventDefault` can skip the store update and the corresponding geometry batch entry.
- React: `onBlocksGeometryChange` mapped to `blocks-geometry-change`.
- MiniMap listens to `blocks-geometry-change` in addition to `block-change`.
- Flush pending geometry on drag end (`DragService`).
- E2E: `e2e/tests/block/block-geometry-batching.spec.ts`.

## Notes
- `blocks-geometry-change` payload: `{ id, x, y, width, height }` per block only.
- Export `TBlockGeometrySnapshot` type from the package root.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce coalesced per-frame block geometry change events and wire them through the store, plugins, React API, and drag lifecycle.

New Features:
- Add a blocks-geometry-change graph event that batches per-block geometry snapshots at most once per animation frame.
- Expose a new onBlocksGeometryChange React callback mapped to the blocks-geometry-change graph event.
- Export the TBlockGeometrySnapshot type from the package root for consumers.

Enhancements:
- Emit block-change with a shallow block snapshot so preventDefault can cancel position updates and associated geometry batching.
- Update the MiniMap layer to react to both block-change and blocks-geometry-change events for more efficient re-rendering.
- Ensure group drags only update blocks when groups contain members and flush pending geometry batches on drag end.
- Add a lightweight asTBlockShallow snapshot method on BlockState for event payloads.

Tests:
- Add end-to-end tests covering block-change plus coalesced blocks-geometry-change behavior for single-block, multi-block, grouped drags, and preventDefault handling.