### PR TITLE
fix(dragListener): prevent spurious DRAG_UPDATE after drag ends

### DIFF
--- a/src/components/canvas/GraphComponent/index.tsx
+++ b/src/components/canvas/GraphComponent/index.tsx
@@ -220,7 +220,7 @@ export class GraphComponent<
             prevCoords = startCoords;
           },
           onUpdate: (event: MouseEvent) => {
-            if (!startCoords?.length) return;
+            if (!startCoords || !prevCoords) return;
 
             const [canvasX, canvasY] = getXY(this.context.canvas, event);
             const currentCoords = this.context.camera.applyToPoint(canvasX, canvasY);

--- a/src/utils/functions/dragListener.ts
+++ b/src/utils/functions/dragListener.ts
@@ -141,11 +141,11 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
     document.addEventListener(
       "mouseleave",
       (event) => {
+        finished = true;
         if (started) {
           mouseupBinded(event);
           cleanupDragState();
         }
-        finished = true;
         cleanup();
       },
       { once: true, capture: true }
@@ -172,11 +172,11 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   document.addEventListener(
     "mouseup",
     (event) => {
+      finished = true;
       if (started) {
         mouseupBinded(event);
         cleanupDragState();
       }
-      finished = true;
       cleanup();
     },
     { once: true, capture: true }
@@ -191,10 +191,10 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   );
 
   emitter.on("cancel", () => {
+    finished = true;
     if (started) {
       cleanupDragState();
     }
-    finished = true;
     cleanup();
   });
 


### PR DESCRIPTION
## Summary

- Set `finished = true` before mouseupBinded/cleanupDragState in all three end-of-drag handlers (mouseup, mouseleave, cancel) in dragListener.ts
- Replace `!startCoords?.length` with `!startCoords || !prevCoords` in GraphComponent.onDrag

## Root Cause

handleCameraChange guards on `started && !finished && lastMouseEvent` before emitting DRAG_UPDATE. finished was assigned after cleanup calls, leaving a window where it was still false. The original crash was startDragCoords.length (TypeError on undefined) — patched in #194 with optional chaining, but the underlying issue remained.

## Fix

Move `finished = true` to the top of each end-of-drag handler so handleCameraChange sees the flag and skips the DRAG_UPDATE emit entirely.

## Test plan
- [ ] Drag a block/group and release — no console errors
- [ ] All existing tests pass (npm test)

## Summary by Sourcery

Ensure drag interactions are correctly finalized to avoid spurious drag updates after a drag ends.

Bug Fixes:
- Set the drag completion flag before invoking drag end handlers to prevent DRAG_UPDATE emissions after the drag has finished.
- Harden drag update handling in the graph component by guarding against missing start or previous coordinates to avoid runtime errors.