### PR TITLE
fix(Groups): prevent stale state from overwriting group drag position

### DIFF
--- a/src/components/canvas/groups/Group.ts
+++ b/src/components/canvas/groups/Group.ts
@@ -287,9 +287,12 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
       if (this.isDragging) {
         // Suppress rect update during drag to prevent the block bounding-box signal chain
         // from overwriting the position set by handleDrag / subclass snapping logic.
+        // Use getState() instead of this.state to get the pending nextState (which includes
+        // the rect set by handleDrag in the same frame), preventing it from being overwritten
+        // with the stale this.state.rect.
         const { rect: _rect, ...groupWithoutRect } = group;
         this.setState({
-          ...this.state,
+          ...this.getState(),
           ...groupWithoutRect,
         } as T);
       } else {


### PR DESCRIPTION
## Summary

- Fixed a bug where groups drag much slower than blocks (or appear stuck)
- Root cause: `subscribeToGroup` was using `this.state` (stale) instead of `this.getState()` (pending) when suppressing rect updates during drag

## What changed and why

During group drag, the flow is:
1. `handleDrag()` calls `setState({ rect: newPos })` → stores new rect in `data.nextState` (but `this.state` is NOT updated until the render cycle)
2. `onDragUpdate` moves the contained blocks
3. Block position signals fire **synchronously**, triggering `subscribeToGroup`
4. With `isDragging=true`, the handler calls `setState({ ...this.state, ...groupWithoutRect })`

The bug: `this.state.rect` is the **stale original position**. Since `data.nextState` already exists from step 1, `setState` hits the `else` branch and does `assign(data.nextState, { rect: stalePos, ... })`, **overwriting** the correct rect set by `handleDrag` back to the initial position. This repeats every frame, making the group appear stuck.

**Fix:** Replace `this.state` with `this.getState()` which returns `data.nextState` when a pending state update exists, preserving the correct rect from `handleDrag`.

## Files changed

- `src/components/canvas/groups/Group.ts` — one-line fix in `subscribeToGroup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix group dragging behavior where groups could appear stuck or move more slowly than blocks due to stale state overwriting the pending drag rect.