### PR TITLE
chore: exported more label utils

### DIFF
--- a/src/components/canvas/connections/index.ts
+++ b/src/components/canvas/connections/index.ts
@@ -5,3 +5,4 @@ export * from "./BezierMultipointConnection";
 export * from "./types";
 export * from "./Arrow";
 export * from "./BatchPath2D";
+export * from "./labelHelper";

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ export { createAnchorPortId, createBlockPointPortId, createPortId } from "./stor
 export { ECanChangeBlockGeometry, ECanDrag } from "./store/settings";
 export { getFontSize, type TMeasureTextOptions, type TWrapText } from "./utils/functions/text";
 export type { TBlockGeometrySnapshot } from "./store/block/BlocksList";
-export { type TMeasureTextOptions, type TWrapText } from "./utils/functions/text";
 export { ESchedulerPriority } from "./lib/Scheduler";
 export { debounce, throttle, schedule } from "./utils/functions";
 export * from "./utils/renderers/text";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export type { AnchorState } from "./store/anchor/Anchor";
 export type { TPort, TPortId } from "./store/connection/port/Port";
 export { createAnchorPortId, createBlockPointPortId, createPortId } from "./store/connection/port/utils";
 export { ECanChangeBlockGeometry, ECanDrag } from "./store/settings";
-export { type TMeasureTextOptions, type TWrapText } from "./utils/functions/text";
+export { getFontSize, type TMeasureTextOptions, type TWrapText } from "./utils/functions/text";
 export { ESchedulerPriority } from "./lib/Scheduler";
 export { debounce, throttle, schedule } from "./utils/functions";
 export * from "./utils/renderers/text";


### PR DESCRIPTION
I want to add labels like these

<img width="363" height="113" alt="изображение" src="https://github.com/user-attachments/assets/26dc2655-854d-40f5-a1f7-2c5af0f029de" />

## Summary by Sourcery

Expose new text measurement utilities and connection label helpers from the public API.

New Features:
- Export the getFontSize utility from the text functions module.
- Export the canvas connection label helper module from the connections package.