### PR TITLE
fix(groups): toggle selection on meta-click

### DIFF
--- a/src/components/canvas/groups/Group.ts
+++ b/src/components/canvas/groups/Group.ts
@@ -115,14 +115,17 @@ export class Group<T extends TGroup = TGroup> extends GraphComponent<TGroupProps
 
     this.subscribeToGroup();
 
-    this.addEventListener("click", (event) => {
-      event.stopPropagation();
-      this.groupState.setSelection(
-        true,
-        !isMetaKeyEvent(event as MouseEvent | KeyboardEvent) ? ESelectionStrategy.REPLACE : ESelectionStrategy.APPEND
-      );
-    });
+    this.addEventListener("click", this.handleClick);
   }
+
+  protected handleClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    const isMeta = isMetaKeyEvent(event);
+    this.groupState.setSelection(
+      !isMeta ? true : !this.groupState.$selected.value,
+      !isMeta ? ESelectionStrategy.REPLACE : ESelectionStrategy.APPEND
+    );
+  };
 
   /**
    * Set the highlighted state of the group


### PR DESCRIPTION
Meta/ctrl-clicking an already-selected group did not deselect it because the click handler always passed `selected = true` to `setSelection`. The APPEND strategy with `selected = true` is a no-op for an already-selected id, so the click silently did nothing.

Mirror the Block click handler: pass `!$selected.value` when the meta key is held, so the group toggles on each ctrl/cmd-click.

## Summary by Sourcery

Fix group selection behavior on canvas click events.

Bug Fixes:
- Allow meta/ctrl-clicking an already-selected group to toggle its selection state instead of being a no-op.

Enhancements:
- Extract the group click handling logic into a dedicated handler method for reuse and clarity.