### PR TITLE
fix(camera): don't apply PAN_SPEED to pointer drag

### DIFF
--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -220,8 +220,12 @@ export type TGraphConstants = {
      */
     PINCH_ZOOM_SPEED: number;
     /**
-     * Multiplier for camera pan speed applied to both mouse drag and trackpad swipe gestures.
-     * Does not affect auto-panning (see AUTO_PAN_SPEED) or zoom speed (see SPEED, PINCH_ZOOM_SPEED).
+     * Multiplier for camera pan speed applied to trackpad two-finger swipe (and
+     * mouse-wheel scroll when MOUSE_WHEEL_BEHAVIOR is "scroll"). Pointer drag
+     * (mouse drag and single-finger trackpad drag) tracks the cursor 1:1 and
+     * is not affected — applying a multiplier there would slide the canvas
+     * out from under the cursor. Does not affect auto-panning (see AUTO_PAN_SPEED)
+     * or zoom speed (see SPEED, PINCH_ZOOM_SPEED).
      *
      * @default 1
      */

--- a/src/services/camera/Camera.ts
+++ b/src/services/camera/Camera.ts
@@ -210,11 +210,10 @@ export class Camera extends EventedComponent<TCameraProps, TComponentState, TGra
     if (!this.lastDragEvent) {
       return;
     }
-    const panSpeed = this.context.constants.camera.PAN_SPEED;
-    this.camera.move(
-      (event.pageX - this.lastDragEvent.pageX) * panSpeed,
-      (event.pageY - this.lastDragEvent.pageY) * panSpeed
-    );
+    // No PAN_SPEED multiplier here: pointer drag tracks the cursor 1:1, otherwise
+    // the canvas slides out from under the pointer. PAN_SPEED only scales
+    // wheel-delta-driven trackpad swipes (see handleTrackpadMove).
+    this.camera.move(event.pageX - this.lastDragEvent.pageX, event.pageY - this.lastDragEvent.pageY);
     this.lastDragEvent = event;
   }
 


### PR DESCRIPTION
## Problem

`PAN_SPEED` was applied to **both** the wheel-driven trackpad swipe (`handleTrackpadMove`) and the pointer drag (`onDragUpdate`). Pointer drag covers two cases:

1. Mouse: pressing left button on empty canvas and dragging.
2. Trackpad: single-finger press-and-drag (the OS converts it to a regular pointer drag, not a wheel event).

In both cases the delta passed to `camera.move()` is the literal cursor displacement (`event.pageX - lastDragEvent.pageX`). Multiplying it by `PAN_SPEED > 1` makes the canvas slide out from under the pointer — the cursor and the grabbed point stop tracking 1:1.

Two-finger trackpad swipes go through `wheel` events with abstract `deltaX/deltaY` units, so a multiplier there is meaningful and stays.

## Fix

- `Camera.onDragUpdate`: drop the `PAN_SPEED` multiplier; pointer drag now tracks the cursor 1:1 regardless of `PAN_SPEED`.
- `handleTrackpadMove`: unchanged — still scales wheel deltas by `PAN_SPEED`.
- Updated `PAN_SPEED` JSDoc in `graphConfig.ts` to reflect the new semantics (trackpad swipe / wheel scroll only, not pointer drag).

## Summary by Sourcery

Ensure camera pointer drag pans the scene 1:1 with cursor movement instead of being affected by the configurable pan speed multiplier.

Bug Fixes:
- Stop applying PAN_SPEED to pointer-based camera dragging so the grabbed point stays aligned with the cursor.

Documentation:
- Clarify PAN_SPEED documentation to specify that it only affects wheel and two-finger trackpad swipe panning, not pointer drag.