### PR TITLE
fix(anchor): eliminate position flash by switching to useLayoutEffect

### DIFF
--- a/src/react-components/Anchor.css
+++ b/src/react-components/Anchor.css
@@ -20,8 +20,8 @@
 }
 
 .graph-block-anchor.graph-block-position-absolute {
-  --x: var(--graph-block-anchor-x, 0px);
-  --y: var(--graph-block-anchor-y, 0px);
+  --x: var(--graph-block-anchor-x, -99999px);
+  --y: var(--graph-block-anchor-y, -99999px);
   --x-offset: calc(var(--width) / 2);
   --y-offset: calc(var(--height) / 2);
 

--- a/src/react-components/hooks/useBlockAnchorState.ts
+++ b/src/react-components/hooks/useBlockAnchorState.ts
@@ -3,7 +3,7 @@ import { Graph } from "../../graph";
 import { AnchorState } from "../../store/anchor/Anchor";
 
 import { useBlockState } from "./useBlockState";
-import { useComputedSignal, useSignalEffect } from "./useSignal";
+import { useComputedSignal, useSignalLayoutEffect } from "./useSignal";
 
 export function useBlockAnchorState(graph: Graph, anchor: TAnchor): AnchorState | undefined {
   const blockState = useBlockState(graph, anchor.blockId);
@@ -19,7 +19,7 @@ export function useBlockAnchorPosition(
   state: AnchorState | undefined,
   anchorContainerRef: React.MutableRefObject<HTMLDivElement> | undefined
 ) {
-  useSignalEffect(() => {
+  useSignalLayoutEffect(() => {
     if (!state || !anchorContainerRef?.current) {
       return;
     }

--- a/src/react-components/hooks/useSignal.ts
+++ b/src/react-components/hooks/useSignal.ts
@@ -1,4 +1,4 @@
-import { DependencyList, useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import { DependencyList, useCallback, useEffect, useLayoutEffect, useMemo, useSyncExternalStore } from "react";
 
 import { computed, effect } from "@preact/signals-core";
 import type { Signal } from "@preact/signals-core";
@@ -62,6 +62,24 @@ export function useComputedSignal<T>(compute: () => T, deps: DependencyList) {
 export function useSignalEffect(effectFn: () => void, deps: DependencyList) {
   const handle = useFn(effectFn);
   useEffect(() => {
+    return effect(() => handle());
+  }, deps);
+}
+
+/**
+ * Like useSignalEffect but runs synchronously after DOM mutations, before the browser paints.
+ * Use when signal changes must be reflected in the DOM without a visible frame delay.
+ *
+ * @example
+ * ```tsx
+ * useSignalLayoutEffect(() => {
+ *   ref.current?.style.setProperty("--x", `${signal.value}px`);
+ * }, [signal]);
+ * ```
+ */
+export function useSignalLayoutEffect(effectFn: () => void, deps: DependencyList) {
+  const handle = useFn(effectFn);
+  useLayoutEffect(() => {
     return effect(() => handle());
   }, deps);
 }


### PR DESCRIPTION
## Summary

- Add `useSignalLayoutEffect` — synchronous variant of `useSignalEffect` that runs via `useLayoutEffect` instead of `useEffect`
- Switch `useBlockAnchorPosition` to use it so CSS variables are applied before the browser paints
- Default anchor CSS fallback position to `-99999px` so anchors without a calculated position are hidden off-screen instead of appearing at `0,0`

## Problem

`useEffect` fires asynchronously after the browser paints, causing anchors to flash at their default position (`0px, 0px` → top-left corner of the block) for one frame before snapping to the correct coordinates. The position was already known at render time — it just wasn't applied synchronously.

## Test Plan

- [ ] Verify anchors appear at correct position immediately without flicker on initial load
- [ ] Verify anchor positions update correctly when block moves
- [ ] Verify existing tests pass (`npm test`)

## Summary by Sourcery

Prevent block anchors from briefly rendering at an incorrect position by making their position updates synchronous and hiding them off-screen until coordinates are available.

New Features:
- Introduce useSignalLayoutEffect as a layout-effect-based variant of useSignalEffect for synchronous DOM updates driven by signals.

Bug Fixes:
- Ensure block anchor positions are applied before paint to eliminate the visible flicker at the default position.
- Hide anchors off-screen by default when no position is available instead of rendering them at the top-left corner.

Enhancements:
- Refine anchor positioning hooks to use the new synchronous signal layout effect for more accurate visual updates.