### PR TITLE
fix(wheel): improve cross-platform wheel intent and suppress text selection on drag

### DIFF
--- a/docs/system/camera.md
+++ b/docs/system/camera.md
@@ -103,11 +103,11 @@ const graph = new Graph(canvas, {
 - With Shift: Horizontal scrolling (left/right along X axis)
 
 **Important notes:**
-- `MOUSE_WHEEL_BEHAVIOR` affects **mouse wheel** classification in `resolveWheelIntent` (I4 rules). It does **not** change integer trackpad scroll, which always resolves to pan.
+- `MOUSE_WHEEL_BEHAVIOR` affects **mouse wheel** classification in `resolveWheelIntent` (I4 rules), including large integer PIXEL steps on Chromium (Windows/Edge). Small integer trackpad ticks and rapid-stream trackpad scroll always resolve to pan (I3).
 - Scroll direction switching with Shift is an environment-dependent behavior according to [W3C UI Events specification](https://w3c.github.io/uievents/#events-wheelevents).
 - Different browsers and operating systems may handle Shift+wheel differently.
 - **Trackpad** gestures also pass through `resolveWheelIntent` (see [Wheel Intent Resolution](./wheel-intent.md)):
-  - Two-finger swipe (integer PIXEL deltas) → pan
+  - Two-finger swipe (small integer PIXEL, or large integer in a rapid stream) → pan
   - Pinch-to-zoom (Ctrl/Cmd + scroll) → zoom with `PINCH_ZOOM_SPEED`
   - Horizontal / diagonal two-finger swipe → pan (I2)
 - Settings can be updated at runtime using `graph.setConstants()`.

--- a/docs/system/wheel-intent.md
+++ b/docs/system/wheel-intent.md
@@ -42,25 +42,36 @@ Rules are evaluated in priority order; the first match wins. Debug logs use **ru
 
 ### Trackpad vs mouse: `deltaMode` and delta shape
 
-Trackpads **always** emit `deltaMode === 0` (`DOM_DELTA_PIXEL`). Mechanical mouse wheels use `LINE` (1) or `PAGE` (2), or smooth-scroll **fractional** PIXEL deltas.
+Trackpads **always** emit `deltaMode === 0` (`DOM_DELTA_PIXEL`). On Chromium (Chrome/Edge), **mouse wheels also use PIXEL mode** with integer deltas (often ±100 per notch). Firefox still uses LINE/PAGE for mice.
 
 | Signal | Source | Resolver |
 |--------|--------|----------|
 | `deltaMode !== 0` (LINE/PAGE) | **Mouse** wheel | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
-| `deltaMode === 0` + **integer** `deltaX`/`deltaY` | **Trackpad** | **Pan** (`I3:integer-trackpad` / `I3:integer-trackpad-slow`) |
+| `deltaMode === 0` + **small integer** `deltaX`/`deltaY` (< 20 px) | **Trackpad** | **Pan** (I3) |
+| `deltaMode === 0` + **large integer** in rapid stream (< 38 ms) | **Trackpad** fast scroll | **Pan** (I3) |
+| `deltaMode === 0` + **isolated large integer** (≥ 20 px, not rapid) | **Mouse** (Chromium) | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
+| `deltaMode === 0` + **legacy wheelDelta ≈ ±120** | **Mouse** (Chromium/Edge) | **I4** (never I3, even in rapid stream) |
 | `deltaMode === 0` + **fractional** deltas | **Mouse** smooth-scroll | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
 
 Integer check uses `Number.isInteger` on raw `deltaX` and `deltaY` (PIXEL mode only).
 
 ---
 
-### I1 — Pinch-to-zoom
+### I1 — Trackpad modifier zoom (pinch / Cmd / Ctrl+scroll)
 
-**Condition**: `(ctrlKey || metaKey)` AND `(hasFractionalDelta || isSmallDelta)`
+**Condition**: `(ctrlKey || metaKey) && deltaMode === PIXEL`
 
 **Intent**: Zoom (`I1:pinch`)
 
-The OS synthesises `ctrlKey=true` for trackpad pinch-to-zoom. Requiring fractional-or-small delta filters out Ctrl+scroll on a mechanical wheel (large steps, typically ≥ 20 px on the smooth-scroll ramp).
+Trackpads always emit `deltaMode === 0` (PIXEL). When a zoom modifier is held, every wheel tick is zoom — including fast scroll with **integer** deltas and the fractional inertia tail:
+
+| Platform | Modifier | Gesture |
+|----------|----------|---------|
+| macOS | `metaKey` | Cmd + two-finger scroll |
+| macOS | `ctrlKey` | Pinch-to-zoom (OS-synthesised) |
+| Windows / Linux | `ctrlKey` | Ctrl + two-finger scroll |
+
+Mechanical mouse wheels use LINE/PAGE (`deltaMode !== 0`) and stay on **I4** per `MOUSE_WHEEL_BEHAVIOR`.
 
 Camera applies `PINCH_ZOOM_SPEED` when {@link isPinchZoomGesture} is true (same condition as I1).
 
@@ -78,14 +89,21 @@ Ignores small `deltaX` noise on predominantly vertical mouse wheel ticks (trackp
 
 ### I3 — Integer trackpad (PIXEL mode)
 
-**Condition**: `deltaMode === 0` + integer `deltaX`/`deltaY` (any magnitude; horizontal/diagonal handled by I2 first)
+**Condition**: `deltaMode === 0` + integer `deltaX`/`deltaY`, and either:
+
+- both axes **< 20 px** (normalized peak), **or**
+- previous event **< 38 ms** ago (rapid stream) with peak **≥ 20 px**
+
+Horizontal/diagonal gestures are handled by I2 first.
 
 **Intent**: Pan
 
 | Timing | Rule id |
 |--------|---------|
 | Rapid stream (&lt; 38 ms since previous event) | `I3:integer-trackpad` |
-| Not rapid | `I3:integer-trackpad-slow` |
+| Not rapid (small ticks only) | `I3:integer-trackpad-slow` |
+
+Isolated large integer PIXEL steps without legacy `wheelDelta` fall through to **I4** via `isDominantAxisLargeWheel`. Events with **legacy `wheelDelta(Y)` ≈ ±120** (Chromium mechanical mouse on Windows) skip **I3** entirely — including rapid streams (~33 ms apart).
 
 ---
 
@@ -100,7 +118,7 @@ Ignores small `deltaX` noise on predominantly vertical mouse wheel ticks (trackp
 | Slow fractional notch | slow, vertical-only, fractional PIXEL in **~3–5 px** band (e.g. Δy ≈ -4.000244) | `I4:fractional-mouse` |
 | Burst smoothing | within **120 ms** after an I4 step, vertical-only fractional event | `I4-burst:smoothing` |
 
-Integer PIXEL steps are trackpad — handled by I3, never I4. `I4:fractional-mouse` starts the burst window.
+Integer PIXEL steps **≥ 20 px** outside a rapid stream are mouse (I4), not I3. `I4:fractional-mouse` starts the burst window.
 
 ---
 
@@ -125,13 +143,13 @@ Integer PIXEL steps are trackpad — handled by I3, never I4. `I4:fractional-mou
 ```
 WheelEvent arrives
 │
-├─ I1: ctrl/meta + (fractional or small)?
+├─ I1: (ctrlKey or metaKey) + PIXEL delta?
 │     → Zoom
 │
 ├─ I2: diagonal OR predominant horizontal?
 │     → Pan
 │
-├─ I3: integer PIXEL delta (trackpad)?
+├─ I3: small integer PIXEL, or large integer in rapid stream?
 │     → Pan  (I3:integer-trackpad / I3:integer-trackpad-slow)
 │
 ├─ I4: mouse wheel step OR large single-axis step?
@@ -242,5 +260,7 @@ enableWheelIntentDebug((entry) => {
 ```
 
 Debug hooks are explicit opt-in. Each wheel event logs two plain-text lines: a one-line summary and a `JSON.stringify` payload you can copy from the console.
+
+**Storybook dev stand:** run `npm run storybook` → **Dev / WheelIntentProbe** — live table of raw `WheelEvent` fields plus resolver rule/signals; copy JSON after reproducing on your OS/device.
 
 See also [Camera](./camera.md) for `MOUSE_WHEEL_BEHAVIOR` and camera constants.

--- a/docs/system/wheel-intent.md
+++ b/docs/system/wheel-intent.md
@@ -50,7 +50,7 @@ Trackpads **always** emit `deltaMode === 0` (`DOM_DELTA_PIXEL`). On Chromium (Ch
 | `deltaMode === 0` + **small integer** `deltaX`/`deltaY` (< 20 px) | **Trackpad** | **Pan** (I3) |
 | `deltaMode === 0` + **large integer** in rapid stream (< 38 ms) | **Trackpad** fast scroll | **Pan** (I3) |
 | `deltaMode === 0` + **isolated large integer** (≥ 20 px, not rapid) | **Mouse** (Chromium) | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
-| `deltaMode === 0` + **legacy wheelDelta ≈ ±120** | **Mouse** (Chromium/Edge) | **I4** (never I3, even in rapid stream) |
+| `deltaMode === 0` + **legacy wheelDelta ≈ ±120** | **Mouse** (Chromium/Edge) | **I4** (never I3, even in a rapid stream) |
 | `deltaMode === 0` + **fractional** deltas | **Mouse** smooth-scroll | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
 
 Integer check uses `Number.isInteger` on raw `deltaX` and `deltaY` (PIXEL mode only).
@@ -261,6 +261,6 @@ enableWheelIntentDebug((entry) => {
 
 Debug hooks are explicit opt-in. Each wheel event logs two plain-text lines: a one-line summary and a `JSON.stringify` payload you can copy from the console.
 
-**Storybook dev stand:** run `npm run storybook` → **Dev / WheelIntentProbe** — live table of raw `WheelEvent` fields plus resolver rule/signals; copy JSON after reproducing on your OS/device.
+**Storybook dev panel:** run `npm run storybook` → **Dev / WheelIntentProbe** — live table of raw `WheelEvent` fields plus resolver rule/signals; copy JSON after reproducing on your OS/device.
 
 See also [Camera](./camera.md) for `MOUSE_WHEEL_BEHAVIOR` and camera constants.

--- a/src/services/camera/Camera.ts
+++ b/src/services/camera/Camera.ts
@@ -195,6 +195,9 @@ export class Camera extends EventedComponent<TCameraProps, TComponentState, TGra
       return;
     }
 
+    // Left button on empty canvas — suppress native text selection before pan drag.
+    event.preventDefault();
+
     // Camera drag doesn't need graph sync since it IS the camera
     dragListener(this.ownerDocument, { graph: this.context.graph, autopanning: false, dragCursor: "grabbing" })
       .on(EVENTS.DRAG_START, (event: MouseEvent) => this.onDragStart(event))

--- a/src/services/drag/DragService.ts
+++ b/src/services/drag/DragService.ts
@@ -316,7 +316,15 @@ export class DragService {
    * ```
    */
   public startDrag(callbacks: DragOperationCallbacks, options: DragOperationOptions = {}) {
-    const { document: doc, cursor, autopanning = true, stopOnMouseLeave, threshold, initialEvent } = options;
+    const {
+      document: doc,
+      cursor,
+      autopanning = true,
+      stopOnMouseLeave,
+      threshold,
+      initialEvent,
+      suppressTextSelection,
+    } = options;
     const { onStart, onUpdate, onEnd } = callbacks;
 
     const targetDocument = doc ?? this.graph.getGraphCanvas().ownerDocument;
@@ -327,6 +335,7 @@ export class DragService {
       autopanning,
       stopOnMouseLeave,
       threshold,
+      suppressTextSelection,
     })
       .on(EVENTS.DRAG_START, (event: MouseEvent) => {
         onStart?.(event, initialEvent ? this.getWorldCoords(initialEvent) : this.getWorldCoords(event));

--- a/src/services/drag/types.ts
+++ b/src/services/drag/types.ts
@@ -24,6 +24,11 @@ export type DragOperationOptions = {
    * If not set, uses the first mousemove event.
    */
   initialEvent?: MouseEvent;
+  /**
+   * Blocks browser text selection for the drag session.
+   * @default true
+   */
+  suppressTextSelection?: boolean;
 };
 
 /**

--- a/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.css
+++ b/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.css
@@ -1,0 +1,96 @@
+.wheel-probe-panel {
+  box-sizing: border-box;
+  height: 100%;
+  padding: 12px 16px;
+  overflow: hidden;
+  background: var(--g-color-base-background);
+  border-left: 1px solid var(--g-color-line-generic);
+}
+
+.wheel-probe-table-wrap {
+  flex: 1;
+  min-height: 120px;
+  overflow: auto;
+  border: 1px solid var(--g-color-line-generic);
+  border-radius: 6px;
+}
+
+.wheel-probe-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--g-font-family-monospace, ui-monospace, monospace);
+  font-size: 11px;
+}
+
+.wheel-probe-table th,
+.wheel-probe-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--g-color-line-generic);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.wheel-probe-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--g-color-base-generic);
+}
+
+.wheel-probe-row {
+  cursor: pointer;
+}
+
+.wheel-probe-row:hover {
+  background: var(--g-color-base-simple-hover);
+}
+
+.wheel-probe-row_selected {
+  background: var(--g-color-base-selection);
+}
+
+.wheel-probe-row_zoom td:last-child {
+  color: var(--g-color-text-warning, #ff7700);
+  font-weight: 600;
+}
+
+.wheel-probe-row_pan td:last-child {
+  color: var(--g-color-text-info, #0066ff);
+  font-weight: 600;
+}
+
+.wheel-probe-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--g-color-text-secondary);
+}
+
+.wheel-probe-detail {
+  flex-shrink: 0;
+  max-height: 35%;
+}
+
+.wheel-probe-hidden-copy {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.wheel-probe-json {
+  margin: 0;
+  padding: 8px;
+  overflow: auto;
+  max-height: 220px;
+  border: 1px solid var(--g-color-line-generic);
+  border-radius: 6px;
+  font-family: var(--g-font-family-monospace, ui-monospace, monospace);
+  font-size: 11px;
+  line-height: 1.4;
+  background: var(--g-color-base-generic);
+  user-select: text;
+  cursor: text;
+}

--- a/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
+++ b/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Button, Flex, Label, Switch, Text, TextInput } from "@gravity-ui/uikit";
+import { Button, Flex, Switch, Text, TextInput } from "@gravity-ui/uikit";
 
 import type { TWheelProbeLogEntry } from "./wheelEventCapture";
 import { copyTextToClipboard, formatWheelProbeSummary } from "./wheelEventCapture";
@@ -172,9 +172,12 @@ export function WheelEventLogPanel({
         ) : null}
       </Flex>
 
-      <Label text="Filter">
+      <Flex direction="column" gap={1}>
+        <Text variant="caption-2" color="secondary">
+          Filter
+        </Text>
         <TextInput placeholder="rule, zoom, int, Ctrl…" value={filter} onUpdate={setFilter} size="s" />
-      </Label>
+      </Flex>
 
       <div className="wheel-probe-table-wrap">
         <table className="wheel-probe-table">

--- a/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
+++ b/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
@@ -1,0 +1,251 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Button, Flex, Label, Switch, Text, TextInput } from "@gravity-ui/uikit";
+
+import type { TWheelProbeLogEntry } from "./wheelEventCapture";
+import { copyTextToClipboard, formatWheelProbeSummary } from "./wheelEventCapture";
+
+import "./WheelEventLogPanel.css";
+
+const MAX_ENTRIES_CAP = 500;
+
+type TWheelEventLogPanelProps = {
+  entries: TWheelProbeLogEntry[];
+  mouseWheelBehavior: string;
+  paused: boolean;
+  onPausedChange: (paused: boolean) => void;
+  onClear: () => void;
+};
+
+export function WheelEventLogPanel({
+  entries,
+  mouseWheelBehavior,
+  paused,
+  onPausedChange,
+  onClear,
+}: TWheelEventLogPanelProps): React.ReactElement {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [filter, setFilter] = useState("");
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const jsonPreRef = useRef<HTMLPreElement>(null);
+  const hiddenCopyRef = useRef<HTMLTextAreaElement>(null);
+  const copyFeedbackTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyFeedbackTimerRef.current !== null) {
+        window.clearTimeout(copyFeedbackTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showCopyFeedback = useCallback((message: string): void => {
+    setCopyFeedback(message);
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current);
+    }
+    copyFeedbackTimerRef.current = window.setTimeout(() => {
+      setCopyFeedback(null);
+      copyFeedbackTimerRef.current = null;
+    }, 4000);
+  }, []);
+
+  const selectForManualCopy = useCallback(
+    (text: string, selectJsonFallback: boolean): void => {
+      if (selectJsonFallback && jsonPreRef.current) {
+        const range = document.createRange();
+        range.selectNodeContents(jsonPreRef.current);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      } else if (hiddenCopyRef.current) {
+        hiddenCopyRef.current.value = text;
+        hiddenCopyRef.current.focus({ preventScroll: true });
+        hiddenCopyRef.current.select();
+      }
+      showCopyFeedback("Auto-copy blocked — text selected, press Ctrl/Cmd+C");
+    },
+    [showCopyFeedback]
+  );
+
+  const copyFromHiddenTextarea = useCallback((text: string): boolean => {
+    const textarea = hiddenCopyRef.current;
+    if (textarea === null) {
+      return copyTextToClipboard(text);
+    }
+
+    try {
+      textarea.value = text;
+      textarea.focus({ preventScroll: true });
+      textarea.select();
+      textarea.setSelectionRange(0, text.length);
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const runCopy = useCallback(
+    (text: string, selectJsonFallback: boolean): void => {
+      // Sync copy must run in the click handler — await breaks the user-gesture chain in Storybook.
+      if (copyFromHiddenTextarea(text)) {
+        showCopyFeedback("Copied to clipboard");
+        return;
+      }
+
+      const clipboard = navigator.clipboard;
+      if (clipboard?.writeText) {
+        clipboard.writeText(text).then(
+          () => {
+            showCopyFeedback("Copied to clipboard");
+          },
+          () => {
+            selectForManualCopy(text, selectJsonFallback);
+          }
+        );
+        return;
+      }
+
+      selectForManualCopy(text, selectJsonFallback);
+    },
+    [copyFromHiddenTextarea, selectForManualCopy, showCopyFeedback]
+  );
+
+  const filteredEntries = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) {
+      return entries;
+    }
+    return entries.filter((entry) => formatWheelProbeSummary(entry).toLowerCase().includes(q));
+  }, [entries, filter]);
+
+  const selectedEntry = useMemo(() => entries.find((entry) => entry.id === selectedId) ?? null, [entries, selectedId]);
+
+  const copyAll = useCallback((): void => {
+    runCopy(JSON.stringify(entries, null, 2), false);
+  }, [entries, runCopy]);
+
+  const copySelected = useCallback((): void => {
+    if (selectedEntry === null) {
+      return;
+    }
+    runCopy(JSON.stringify(selectedEntry, null, 2), true);
+  }, [selectedEntry, runCopy]);
+
+  const selectedJsonText =
+    selectedEntry === null ? "Click a row to inspect full payload" : JSON.stringify(selectedEntry, null, 2);
+
+  const platformHint = entries[0]?.platform ?? navigator.platform;
+
+  return (
+    <Flex direction="column" className="wheel-probe-panel" gap={3}>
+      <textarea ref={hiddenCopyRef} className="wheel-probe-hidden-copy" readOnly tabIndex={-1} aria-hidden="true" />
+      <Flex direction="column" gap={1}>
+        <Text variant="header-1">Wheel intent probe</Text>
+        <Text variant="body-2" color="secondary">
+          Scroll over the canvas with a mouse wheel, trackpad, or modifier keys. Each row is one real{" "}
+          <code>WheelEvent</code> plus <code>resolveWheelIntent</code> output.
+        </Text>
+        <Text variant="caption-2" color="secondary">
+          Platform: {platformHint} · MOUSE_WHEEL_BEHAVIOR: <strong>{mouseWheelBehavior}</strong> · {entries.length}{" "}
+          events (max {MAX_ENTRIES_CAP})
+        </Text>
+      </Flex>
+
+      <Flex gap={3} alignItems="center" wrap="wrap">
+        <Switch checked={paused} onUpdate={onPausedChange}>
+          Pause capture
+        </Switch>
+        <Button view="outlined" size="s" onClick={onClear} disabled={entries.length === 0}>
+          Clear
+        </Button>
+        <Button view="outlined" size="s" onClick={copyAll} disabled={entries.length === 0}>
+          Copy all JSON
+        </Button>
+        <Button view="outlined" size="s" onClick={copySelected} disabled={selectedEntry === null}>
+          Copy selected
+        </Button>
+        {copyFeedback !== null ? (
+          <Text variant="caption-2" color={copyFeedback.startsWith("Copied") ? "positive" : "warning"}>
+            {copyFeedback}
+          </Text>
+        ) : null}
+      </Flex>
+
+      <Label text="Filter">
+        <TextInput placeholder="rule, zoom, int, Ctrl…" value={filter} onUpdate={setFilter} size="s" />
+      </Label>
+
+      <div className="wheel-probe-table-wrap">
+        <table className="wheel-probe-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>+ms</th>
+              <th>Δx</th>
+              <th>Δy</th>
+              <th>mode</th>
+              <th>int</th>
+              <th>keys</th>
+              <th>rule</th>
+              <th>→</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredEntries.length === 0 ? (
+              <tr>
+                <td colSpan={9} className="wheel-probe-empty">
+                  {paused ? "Capture paused" : "No events yet — scroll over the graph"}
+                </td>
+              </tr>
+            ) : (
+              filteredEntries.map((entry) => {
+                const { raw, resolver } = entry;
+                const isSelected = entry.id === selectedId;
+                const keys = [
+                  raw.ctrlKey ? "C" : "",
+                  raw.metaKey ? "M" : "",
+                  raw.shiftKey ? "S" : "",
+                  raw.altKey ? "A" : "",
+                ]
+                  .filter(Boolean)
+                  .join("");
+
+                return (
+                  <tr
+                    key={entry.id}
+                    className={[
+                      "wheel-probe-row",
+                      isSelected ? "wheel-probe-row_selected" : "",
+                      resolver.result === "zoom" ? "wheel-probe-row_zoom" : "wheel-probe-row_pan",
+                    ].join(" ")}
+                    onClick={() => setSelectedId(entry.id)}
+                  >
+                    <td>{entry.id}</td>
+                    <td>{Math.round(resolver.session.timeSinceLastMs)}</td>
+                    <td>{raw.deltaX}</td>
+                    <td>{raw.deltaY}</td>
+                    <td>{raw.deltaModeLabel}</td>
+                    <td>{raw.deltaXIsInteger && raw.deltaYIsInteger ? "✓" : "~"}</td>
+                    <td>{keys || "—"}</td>
+                    <td>{resolver.rule}</td>
+                    <td>{resolver.result}</td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <Flex direction="column" gap={1} className="wheel-probe-detail">
+        <Text variant="subheader-2">Selected event JSON</Text>
+        <pre ref={jsonPreRef} className="wheel-probe-json">
+          {selectedJsonText}
+        </pre>
+      </Flex>
+    </Flex>
+  );
+}
+
+export { MAX_ENTRIES_CAP };

--- a/src/stories/examples/wheelIntentProbe/wheelEventCapture.ts
+++ b/src/stories/examples/wheelIntentProbe/wheelEventCapture.ts
@@ -1,0 +1,114 @@
+import type { TWheelIntentDebugEntry } from "../../../utils/functions/wheelIntent";
+
+const DELTA_MODE_LABELS = ["PIXEL", "LINE", "PAGE"] as const;
+
+type TLegacyWheelEvent = WheelEvent & {
+  wheelDelta?: number;
+  wheelDeltaX?: number;
+  wheelDeltaY?: number;
+};
+
+/** Raw browser fields useful for tuning wheel-intent heuristics. */
+export type TRawWheelEventSnapshot = {
+  deltaX: number;
+  deltaY: number;
+  deltaZ: number;
+  deltaMode: number;
+  deltaModeLabel: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  deltaXIsInteger: boolean;
+  deltaYIsInteger: boolean;
+  wheelDelta: number | null;
+  wheelDeltaX: number | null;
+  wheelDeltaY: number | null;
+};
+
+export type TWheelProbeLogEntry = {
+  id: number;
+  capturedAt: string;
+  platform: string;
+  userAgent: string;
+  raw: TRawWheelEventSnapshot;
+  resolver: TWheelIntentDebugEntry;
+};
+
+export function snapshotRawWheelEvent(event: WheelEvent): TRawWheelEventSnapshot {
+  const legacy = event as TLegacyWheelEvent;
+
+  return {
+    deltaX: event.deltaX,
+    deltaY: event.deltaY,
+    deltaZ: event.deltaZ,
+    deltaMode: event.deltaMode,
+    deltaModeLabel: DELTA_MODE_LABELS[event.deltaMode] ?? String(event.deltaMode),
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+    altKey: event.altKey,
+    deltaXIsInteger: Number.isInteger(event.deltaX),
+    deltaYIsInteger: Number.isInteger(event.deltaY),
+    wheelDelta: legacy.wheelDelta ?? null,
+    wheelDeltaX: legacy.wheelDeltaX ?? null,
+    wheelDeltaY: legacy.wheelDeltaY ?? null,
+  };
+}
+
+export function formatWheelProbeSummary(entry: TWheelProbeLogEntry): string {
+  const { raw, resolver } = entry;
+  const keys = [
+    raw.ctrlKey ? "Ctrl" : "",
+    raw.metaKey ? "Meta" : "",
+    raw.shiftKey ? "Shift" : "",
+    raw.altKey ? "Alt" : "",
+  ]
+    .filter(Boolean)
+    .join("+");
+
+  let intTag = "frac";
+  if (raw.deltaXIsInteger && raw.deltaYIsInteger) {
+    intTag = "int";
+  } else if (raw.deltaXIsInteger || raw.deltaYIsInteger) {
+    intTag = "mixed";
+  }
+
+  return [
+    resolver.rule,
+    "→",
+    resolver.result,
+    `| Δ(${raw.deltaX}, ${raw.deltaY}) ${raw.deltaModeLabel} ${intTag}`,
+    keys ? `| ${keys}` : "",
+    `| +${Math.round(resolver.session.timeSinceLastMs)}ms`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+/**
+ * Sync clipboard copy via hidden textarea (works in Storybook iframe).
+ */
+export function copyTextToClipboard(text: string): boolean {
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "true");
+    textarea.style.position = "fixed";
+    textarea.style.top = "0";
+    textarea.style.left = "0";
+    textarea.style.width = "1px";
+    textarea.style.height = "1px";
+    textarea.style.opacity = "0";
+    textarea.style.pointerEvents = "none";
+    document.body.appendChild(textarea);
+    textarea.focus({ preventScroll: true });
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    const copied = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return copied;
+  } catch {
+    return false;
+  }
+}

--- a/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
+++ b/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { Flex, ThemeProvider } from "@gravity-ui/uikit";
+import type { Meta, StoryObj } from "@storybook/react-webpack5";
+
+import { TBlock } from "../../../components/canvas/blocks/Block";
+import { Graph, GraphState } from "../../../graph";
+import type { TMouseWheelBehavior } from "../../../graphConfig";
+import { createWheelIntentResolver, enableWheelIntentDebug } from "../../../graphConfig";
+import { GraphBlock, GraphCanvas, HookGraphParams, useGraph, useGraphEvent } from "../../../react-components";
+import { useFn } from "../../../react-components/utils/hooks/useFn";
+import { ECanDrag } from "../../../store/settings";
+
+import { MAX_ENTRIES_CAP, WheelEventLogPanel } from "./WheelEventLogPanel";
+import type { TWheelProbeLogEntry } from "./wheelEventCapture";
+import { snapshotRawWheelEvent } from "./wheelEventCapture";
+
+import "./WheelEventLogPanel.css";
+import "@gravity-ui/uikit/styles/styles.css";
+
+const GRAPH_SETTINGS: NonNullable<HookGraphParams["settings"]> = {
+  canDragCamera: true,
+  canZoomCamera: true,
+  canDuplicateBlocks: false,
+  canDrag: ECanDrag.ALL,
+  canCreateNewConnections: false,
+  showConnectionArrows: false,
+  scaleFontSize: 1,
+  useBezierConnections: true,
+  useBlocksAnchors: true,
+  showConnectionLabels: false,
+};
+
+type WheelIntentProbeStoryProps = {
+  mouseWheelBehavior: TMouseWheelBehavior;
+};
+
+function WheelIntentProbeStory({ mouseWheelBehavior }: WheelIntentProbeStoryProps): React.ReactElement {
+  const [entries, setEntries] = useState<TWheelProbeLogEntry[]>([]);
+  const [paused, setPaused] = useState(false);
+  const nextIdRef = useRef(1);
+  const pausedRef = useRef(paused);
+  const pendingRawRef = useRef<ReturnType<typeof snapshotRawWheelEvent> | null>(null);
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  const baseResolveWheelIntent = useMemo(() => createWheelIntentResolver(), []);
+
+  const graphParams = useMemo<HookGraphParams>(
+    () => ({
+      viewConfiguration: {
+        constants: {
+          camera: {
+            MOUSE_WHEEL_BEHAVIOR: mouseWheelBehavior,
+          },
+        },
+      },
+      settings: {
+        ...GRAPH_SETTINGS,
+        resolveWheelIntent: (event: WheelEvent, wb: TMouseWheelBehavior) => {
+          pendingRawRef.current = snapshotRawWheelEvent(event);
+          return baseResolveWheelIntent(event, wb);
+        },
+      },
+    }),
+    [mouseWheelBehavior, baseResolveWheelIntent]
+  );
+
+  const { graph, setEntities, start } = useGraph(graphParams);
+
+  useEffect(() => {
+    enableWheelIntentDebug((resolverEntry) => {
+      if (pausedRef.current) {
+        return;
+      }
+
+      const raw = pendingRawRef.current;
+      pendingRawRef.current = null;
+      if (raw === null) {
+        return;
+      }
+
+      const id = nextIdRef.current;
+      nextIdRef.current += 1;
+
+      const probeEntry: TWheelProbeLogEntry = {
+        id,
+        capturedAt: new Date().toISOString(),
+        platform: navigator.platform,
+        userAgent: navigator.userAgent,
+        raw,
+        resolver: resolverEntry,
+      };
+
+      setEntries((prev) => [probeEntry, ...prev].slice(0, MAX_ENTRIES_CAP));
+    });
+
+    return () => {
+      enableWheelIntentDebug(null);
+    };
+  }, []);
+
+  useGraphEvent(graph, "state-change", ({ state }) => {
+    if (state === GraphState.ATTACHED) {
+      start();
+      graph.zoomTo("center", { padding: 300 });
+    }
+  });
+
+  useLayoutEffect(() => {
+    setEntities({
+      blocks: [
+        {
+          x: 200,
+          y: 280,
+          width: 220,
+          height: 140,
+          id: "A",
+          is: "Block",
+          selected: false,
+          name: "Block A",
+          anchors: [],
+        },
+        {
+          x: 520,
+          y: 280,
+          width: 220,
+          height: 140,
+          id: "B",
+          is: "Block",
+          selected: false,
+          name: "Block B",
+          anchors: [],
+        },
+      ],
+      connections: [{ sourceBlockId: "A", targetBlockId: "B" }],
+    });
+  }, [setEntities]);
+
+  const renderBlockFn = useFn((g: Graph, block: TBlock) => (
+    <GraphBlock graph={g} block={block}>
+      {block.name}
+    </GraphBlock>
+  ));
+
+  return (
+    <ThemeProvider theme="light">
+      <Flex style={{ height: "100vh", width: "100vw" }}>
+        <div style={{ flex: "1 1 58%", minWidth: 0, position: "relative" }}>
+          <GraphCanvas graph={graph} renderBlock={renderBlockFn} />
+        </div>
+        <div style={{ flex: "0 0 42%", minWidth: 320, maxWidth: 640 }}>
+          <WheelEventLogPanel
+            entries={entries}
+            mouseWheelBehavior={mouseWheelBehavior}
+            paused={paused}
+            onPausedChange={setPaused}
+            onClear={() => setEntries([])}
+          />
+        </div>
+      </Flex>
+    </ThemeProvider>
+  );
+}
+
+const meta: Meta<typeof WheelIntentProbeStory> = {
+  title: "Dev/WheelIntentProbe",
+  component: WheelIntentProbeStory,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Live capture of real WheelEvent payloads and resolveWheelIntent output. Use on Windows/macOS with mouse and trackpad, then copy JSON for heuristic tuning.",
+      },
+    },
+  },
+  argTypes: {
+    mouseWheelBehavior: {
+      control: "select",
+      options: ["scroll", "zoom"],
+      description: "MOUSE_WHEEL_BEHAVIOR constant passed to the resolver.",
+    },
+  },
+  args: {
+    mouseWheelBehavior: "zoom",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WheelIntentProbeStory>;
+
+export const Default: Story = {};

--- a/src/utils/functions/dragListener.ts
+++ b/src/utils/functions/dragListener.ts
@@ -16,7 +16,38 @@ export type DragListenerOptions = {
    * Default: 0 (drag starts immediately on first mousemove)
    */
   threshold?: number;
+  /**
+   * Blocks browser text selection for the drag session (selectstart + temporary user-select).
+   * @default true
+   */
+  suppressTextSelection?: boolean;
 };
+
+function getDragListenerDocument(node: Document | HTMLDivElement | HTMLCanvasElement): Document {
+  if (node instanceof Document) {
+    return node;
+  }
+  return node.ownerDocument;
+}
+
+/** Prevents browser text selection for the duration of a drag gesture. */
+function installTextSelectionSuppression(doc: Document, graph?: Graph): () => void {
+  const root = graph?.getGraphCanvas() ?? doc.documentElement;
+  doc.defaultView?.getSelection()?.removeAllRanges();
+
+  const onSelectStart = (event: Event): void => {
+    event.preventDefault();
+  };
+  doc.addEventListener("selectstart", onSelectStart, { capture: true });
+
+  const prevUserSelect = root.style.userSelect;
+  root.style.userSelect = "none";
+
+  return (): void => {
+    doc.removeEventListener("selectstart", onSelectStart, { capture: true });
+    root.style.userSelect = prevUserSelect;
+  };
+}
 
 export function dragListener(document: Document | HTMLDivElement | HTMLCanvasElement, options?: DragListenerOptions) {
   // Support legacy boolean parameter for backward compatibility
@@ -25,8 +56,14 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   const dragCursor = options?.dragCursor;
   const component = options?.component;
   const autopanning = options?.autopanning ?? Boolean(graph);
+  const suppressTextSelection = options?.suppressTextSelection ?? true;
   // Use provided threshold, or get from graph settings, or default to 0
   const threshold = options?.threshold ?? graph?.rootStore.settings.$dragThreshold.value ?? 0;
+
+  const dragDocument = getDragListenerDocument(document);
+  const releaseTextSelection = suppressTextSelection
+    ? installTextSelectionSuppression(dragDocument, graph)
+    : (): void => undefined;
 
   let started = false;
   let finished = false;
@@ -79,6 +116,10 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   const startDrag = (event: MouseEvent): void => {
     started = true;
     thresholdExceeded = true;
+    if (suppressTextSelection) {
+      event.preventDefault();
+      dragDocument.defaultView?.getSelection()?.removeAllRanges();
+    }
 
     // Setup drag state
     if (graph) {
@@ -112,7 +153,8 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
     }
   };
 
-  const cleanup = () => {
+  const cleanup = (): void => {
+    releaseTextSelection();
     if (graph && autopanning) {
       graph.off("camera-change", handleCameraChange);
     }

--- a/src/utils/functions/dragListener.ts
+++ b/src/utils/functions/dragListener.ts
@@ -61,9 +61,19 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   const threshold = options?.threshold ?? graph?.rootStore.settings.$dragThreshold.value ?? 0;
 
   const dragDocument = getDragListenerDocument(document);
-  const releaseTextSelection = suppressTextSelection
-    ? installTextSelectionSuppression(dragDocument, graph)
-    : (): void => undefined;
+  let releaseTextSelection: (() => void) | null = null;
+
+  const ensureTextSelectionSuppressed = (): void => {
+    if (!suppressTextSelection || releaseTextSelection !== null) {
+      return;
+    }
+    releaseTextSelection = installTextSelectionSuppression(dragDocument, graph);
+  };
+
+  const cleanupTextSelection = (): void => {
+    releaseTextSelection?.();
+    releaseTextSelection = null;
+  };
 
   let started = false;
   let finished = false;
@@ -117,6 +127,7 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
     started = true;
     thresholdExceeded = true;
     if (suppressTextSelection) {
+      ensureTextSelectionSuppressed();
       event.preventDefault();
       dragDocument.defaultView?.getSelection()?.removeAllRanges();
     }
@@ -154,7 +165,7 @@ export function dragListener(document: Document | HTMLDivElement | HTMLCanvasEle
   };
 
   const cleanup = (): void => {
-    releaseTextSelection();
+    cleanupTextSelection();
     if (graph && autopanning) {
       graph.off("camera-change", handleCameraChange);
     }

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -19,6 +19,22 @@ function makeWheelEvent(
   });
 }
 
+/** Chromium/Edge on Windows: integer PIXEL deltaY + legacy wheelDeltaY ≈ ∓120. */
+function makeChromiumMouseWheelEvent(
+  overrides: Partial<{
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }> = {}
+): WheelEvent {
+  const deltaY = overrides.deltaY ?? 100;
+  const event = makeWheelEvent({ deltaY, ...overrides });
+  const legacyDelta = deltaY > 0 ? -120 : 120;
+  Object.defineProperty(event, "wheelDelta", { configurable: true, value: legacyDelta });
+  Object.defineProperty(event, "wheelDeltaY", { configurable: true, value: legacyDelta });
+  return event;
+}
+
 describe("createWheelIntentResolver", () => {
   let nowMs = 0;
 
@@ -36,13 +52,36 @@ describe("createWheelIntentResolver", () => {
     nowMs += ms;
   }
 
-  it("slow integer vertical wheel resolves to pan (integer PIXEL = trackpad)", () => {
+  it("slow large integer PIXEL step follows MOUSE_WHEEL_BEHAVIOR (Chromium/Windows mouse)", () => {
     const resolver = createWheelIntentResolver();
-    const intent = resolver(makeWheelEvent({ deltaY: -100 }), "zoom");
-    expect(intent).toBe(EWheelIntent.Pan);
+
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "scroll")).toBe(EWheelIntent.Pan);
   });
 
-  it("integer PIXEL scroll stays pan in both directions and at any magnitude", () => {
+  it("Chromium mouse rapid stream with wheelDelta ±120 stays zoom (Windows log repro)", () => {
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    const resolver = createWheelIntentResolver();
+    const tick = (): EWheelIntent => resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom");
+
+    expect(tick()).toBe(EWheelIntent.Zoom);
+    advanceMs(33);
+    expect(tick()).toBe(EWheelIntent.Zoom);
+    advanceMs(33);
+    expect(tick()).toBe(EWheelIntent.Zoom);
+    advanceMs(33);
+    expect(tick()).toBe(EWheelIntent.Zoom);
+
+    expect(entries.every((entry) => entry.rule === "I4:mouse-wheel-step")).toBe(true);
+    expect(entries.every((entry) => entry.result === EWheelIntent.Zoom)).toBe(true);
+    expect(entries.every((entry) => entry.signals.hasLegacyMouseWheelDelta)).toBe(true);
+  });
+
+  it("small integer PIXEL scroll stays pan (trackpad ticks)", () => {
     const resolver = createWheelIntentResolver();
 
     resolver(makeWheelEvent({ deltaY: 1 }), "zoom");
@@ -51,13 +90,21 @@ describe("createWheelIntentResolver", () => {
     expect(resolver(makeWheelEvent({ deltaY: -1 }), "zoom")).toBe(EWheelIntent.Pan);
     expect(resolver(makeWheelEvent({ deltaY: -11 }), "zoom")).toBe(EWheelIntent.Pan);
     expect(resolver(makeWheelEvent({ deltaY: -20 }), "zoom")).toBe(EWheelIntent.Pan);
+  });
+
+  it("large integer PIXEL scroll stays pan inside a rapid stream (trackpad)", () => {
+    const resolver = createWheelIntentResolver();
+
+    resolver(makeWheelEvent({ deltaY: -20 }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -100 }), "zoom")).toBe(EWheelIntent.Pan);
   });
 
-  it("integer PIXEL scroll with deltaX noise stays pan", () => {
+  it("integer PIXEL scroll with deltaX noise stays pan in rapid stream", () => {
     const resolver = createWheelIntentResolver();
 
+    resolver(makeWheelEvent({ deltaY: -4 }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -100, deltaX: 2 }), "zoom")).toBe(EWheelIntent.Pan);
+    resolver(makeWheelEvent({ deltaY: -4 }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -20, deltaX: 3 }), "zoom")).toBe(EWheelIntent.Pan);
   });
 
@@ -155,6 +202,53 @@ describe("createWheelIntentResolver", () => {
     expect(intent).toBe(EWheelIntent.Zoom);
     expect(entries[0]?.rule).toBe("I1:pinch");
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -2, ctrlKey: true }))).toBe(true);
+  });
+
+  it("Mac Cmd+scroll with large integer deltas resolves to zoom (not trackpad pan)", () => {
+    const resolver = createWheelIntentResolver();
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), "zoom");
+    expect(resolver(makeWheelEvent({ deltaY: -20, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(entries[0]?.rule).toBe("I1:pinch");
+    expect(entries[1]?.rule).toBe("I1:pinch");
+    expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, metaKey: true }))).toBe(true);
+  });
+
+  it("Mac Cmd+scroll stays zoom through inertia tail (fractional small deltas)", () => {
+    const resolver = createWheelIntentResolver();
+
+    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), "zoom");
+    expect(resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    advanceMs(850);
+    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+  });
+
+  it("modifier + large integer PIXEL delta resolves to zoom (trackpad Ctrl/Cmd scroll)", () => {
+    const resolver = createWheelIntentResolver();
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    expect(resolver(makeWheelEvent({ deltaY: -100, ctrlKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(entries[0]?.rule).toBe("I1:pinch");
+    expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, ctrlKey: true }))).toBe(true);
+  });
+
+  it("modifier + LINE mode wheel still follows MOUSE_WHEEL_BEHAVIOR (mouse, not trackpad)", () => {
+    const resolver = createWheelIntentResolver();
+    const lineEvent = makeWheelEvent({
+      deltaY: -1,
+      deltaMode: WheelEvent.DOM_DELTA_LINE,
+      ctrlKey: true,
+    });
+
+    expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(lineEvent, "scroll")).toBe(EWheelIntent.Pan);
   });
 
   it("predominant horizontal scroll resolves to pan", () => {

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -63,6 +63,8 @@ export type TWheelIntentDebugEntry = {
     isSmallDelta: boolean;
     /** Trackpads always emit `deltaMode === DOM_DELTA_PIXEL` (0); mice use LINE/PAGE or PIXEL. */
     isPixelDeltaMode: boolean;
+    /** Deprecated `wheelDelta(Y)` ≈ ±120 on Chromium mechanical mouse wheels. */
+    hasLegacyMouseWheelDelta: boolean;
   };
   /** Winning rule id and resolved intent. */
   rule: string;
@@ -185,6 +187,28 @@ function normalizeWheelDelta(delta: number, deltaMode: number): number {
   return delta;
 }
 
+/** Minimum |wheelDelta| / |wheelDeltaY| for legacy mouse-wheel detection (Chromium ≈ 120). */
+const LEGACY_MOUSE_WHEEL_DELTA_MIN = 100;
+
+type TLegacyWheelEvent = WheelEvent & {
+  wheelDelta?: number;
+  wheelDeltaX?: number;
+  wheelDeltaY?: number;
+};
+
+/**
+ * Chromium still sets deprecated wheelDelta( Y ) on mechanical mouse wheels (typically ±120).
+ * Trackpad scroll usually omits it or uses smaller values.
+ */
+function hasLegacyMouseWheelDelta(event: WheelEvent): boolean {
+  const legacy = event as TLegacyWheelEvent;
+  const axisDelta = legacy.wheelDeltaY ?? legacy.wheelDelta;
+  if (axisDelta === undefined) {
+    return false;
+  }
+  return Math.abs(axisDelta) >= LEGACY_MOUSE_WHEEL_DELTA_MIN;
+}
+
 function createWheelContext(event: WheelEvent): TWheelContext {
   const normX = normalizeWheelDelta(event.deltaX, event.deltaMode);
   const normY = normalizeWheelDelta(event.deltaY, event.deltaMode);
@@ -209,7 +233,7 @@ function createWheelContext(event: WheelEvent): TWheelContext {
 /**
  * Vertical-only wheel step — physical mouse (LINE/PAGE, or PIXEL delta ≥ discrete minimum).
  *
- * PIXEL mode with **integer** deltas is trackpad — excluded here regardless of magnitude.
+ * Small integer PIXEL deltas (< {@link MOUSE_WHEEL_DISCRETE_MIN_PX}) are trackpad ticks — excluded here.
  */
 function isClassicMouseWheelStep(ctx: TWheelContext): boolean {
   const { event, absY, isPixelDeltaMode, hasFractionalDelta } = ctx;
@@ -223,14 +247,28 @@ function isClassicMouseWheelStep(ctx: TWheelContext): boolean {
     return false;
   }
   if (isPixelDeltaMode && !hasFractionalDelta) {
-    return false;
+    // Chromium/Windows: integer PIXEL + legacy wheelDelta ≈ ±120.
+    return hasLegacyMouseWheelDelta(event);
   }
   return true;
 }
 
 /** Trackpad scroll in PIXEL mode: integer `deltaX` and `deltaY`. */
-function isIntegerPixelTrackpadScroll(ctx: TWheelContext): boolean {
-  return ctx.isPixelDeltaMode && !ctx.hasFractionalDelta;
+function isIntegerPixelTrackpadScroll(ctx: TWheelContext, isRapidStream: boolean): boolean {
+  if (!ctx.isPixelDeltaMode || ctx.hasFractionalDelta) {
+    return false;
+  }
+  if (hasLegacyMouseWheelDelta(ctx.event)) {
+    return false;
+  }
+  const peak = Math.max(ctx.absX, ctx.absY);
+  // Small integer ticks: always trackpad (slow scroll, inertia, per-frame deltas).
+  if (peak < MOUSE_WHEEL_DISCRETE_MIN_PX) {
+    return true;
+  }
+  // Large integer steps: trackpad only inside a continuous rapid stream.
+  // Isolated large integer PIXEL steps are mouse wheels on Chromium (Windows/macOS).
+  return isRapidStream;
 }
 
 /** Rapid PIXEL-mode stream with small deltas — fractional trackpad inertia on some drivers. */
@@ -270,13 +308,15 @@ function isDominantAxisLargeWheel(ctx: TWheelContext): boolean {
 }
 
 function isPinchZoomWheelEvent(ctx: TWheelContext): boolean {
-  const { event, hasFractionalDelta, isSmallDelta } = ctx;
-  return (event.ctrlKey || event.metaKey) && (hasFractionalDelta || isSmallDelta);
+  const { event, isPixelDeltaMode } = ctx;
+  // Trackpads always emit PIXEL deltas. A held modifier means zoom on every platform:
+  // Mac Cmd (metaKey), pinch (ctrlKey), Windows/Linux Ctrl+scroll (ctrlKey).
+  return isPixelDeltaMode && (event.ctrlKey || event.metaKey);
 }
 
 /**
- * Returns true for OS-synthesized trackpad pinch-to-zoom gestures (ctrl/meta + fractional or small delta).
- * Used by Camera for pinch zoom speed; excludes Ctrl+scroll on a mechanical wheel (large steps ≥ I4 threshold).
+ * Returns true when a trackpad modifier-zoom gesture is active (PIXEL mode + ctrl/meta).
+ * Used by Camera for {@link PINCH_ZOOM_SPEED}; mechanical wheels (LINE/PAGE) are excluded.
  */
 export function isPinchZoomGesture(event: WheelEvent): boolean {
   return isPinchZoomWheelEvent(createWheelContext(event));
@@ -308,6 +348,7 @@ function buildWheelSignals(ctx: TWheelContext): TWheelIntentDebugEntry["signals"
     hasFractionalDelta: ctx.hasFractionalDelta,
     isSmallDelta: ctx.isSmallDelta,
     isPixelDeltaMode: ctx.isPixelDeltaMode,
+    hasLegacyMouseWheelDelta: hasLegacyMouseWheelDelta(ctx.event),
   };
 }
 
@@ -371,16 +412,18 @@ function emitDebugEntry(
  *
  * | Signal                                | Intent          |
  * |---------------------------------------|-----------------|
- * | ctrlKey / metaKey + scroll            | Zoom (I1)       |
+ * | ctrlKey / metaKey + PIXEL scroll       | Zoom (I1)       |
  * | Horizontal or diagonal movement       | Pan  (I2)       |
  * | Integer PIXEL delta (trackpad)        | Pan  (I3)       |
+ * | Large isolated integer PIXEL step     | Zoom/Pan (I4)*  |
  * | Classic mouse wheel step (fractional) | Zoom/Pan (I4)*  |
  * | Rapid stream + small delta (fractional)| Pan  (I3)      |
  * | Anything else                         | Last intent (I5)|
  *
  * *I4 respects `mouseWheelBehavior`: `"scroll"` → Pan, `"zoom"` → Zoom.
  *
- * Trackpad: `deltaMode === 0` (PIXEL) + **integer** `deltaX`/`deltaY` → pan; **fractional** PIXEL → mouse (I4).
+ * Trackpad: small integer PIXEL ticks, or large integer PIXEL inside a rapid stream → pan (I3).
+ * Isolated large integer PIXEL (Chromium mouse on Windows) → I4 per `mouseWheelBehavior`.
  * LINE/PAGE mode (`deltaMode !== 0`) is never trackpad — always mouse (I4).
  * See `docs/system/wheel-intent.md` for rationale.
  */
@@ -417,10 +460,14 @@ export function createWheelIntentResolver(): TResolveWheelIntent {
     } else if (signals.isDiagonalScroll || signals.isPredominantHorizontalScroll) {
       intent = EWheelIntent.Pan;
       rule = "I2:horizontal-or-diagonal";
-    } else if (isIntegerPixelTrackpadScroll(ctx)) {
+    } else if (isIntegerPixelTrackpadScroll(ctx, isRapidStream)) {
       intent = EWheelIntent.Pan;
       rule = isRapidStream ? "I3:integer-trackpad" : "I3:integer-trackpad-slow";
-    } else if (signals.isDominantAxisLargeWheel || signals.isClassicMouseWheelStep) {
+    } else if (
+      signals.isDominantAxisLargeWheel ||
+      signals.isClassicMouseWheelStep ||
+      signals.hasLegacyMouseWheelDelta
+    ) {
       intent = intentFromMouseWheelBehavior(mouseWheelBehavior);
       rule = signals.isClassicMouseWheelStep ? "I4:mouse-wheel-step" : "I4:large-step";
       markMouseWheelBurst(now);

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -90,6 +90,7 @@ type TWheelContext = {
   isPixelDeltaMode: boolean;
   isSmallDelta: boolean;
   isVerticalOnly: boolean;
+  hasLegacyMouseWheelDelta: boolean;
 };
 
 function getWheelIntentDebugLogger(): TWheelIntentDebugLogger | null {
@@ -227,6 +228,7 @@ function createWheelContext(event: WheelEvent): TWheelContext {
     isPixelDeltaMode,
     isSmallDelta: absX < SMALL_DELTA_THRESHOLD && absY < SMALL_DELTA_THRESHOLD,
     isVerticalOnly: absX < MIN_HORIZONTAL_SCROLL_ABS,
+    hasLegacyMouseWheelDelta: hasLegacyMouseWheelDelta(event),
   };
 }
 
@@ -248,7 +250,7 @@ function isClassicMouseWheelStep(ctx: TWheelContext): boolean {
   }
   if (isPixelDeltaMode && !hasFractionalDelta) {
     // Chromium/Windows: integer PIXEL + legacy wheelDelta ≈ ±120.
-    return hasLegacyMouseWheelDelta(event);
+    return ctx.hasLegacyMouseWheelDelta;
   }
   return true;
 }
@@ -258,7 +260,7 @@ function isIntegerPixelTrackpadScroll(ctx: TWheelContext, isRapidStream: boolean
   if (!ctx.isPixelDeltaMode || ctx.hasFractionalDelta) {
     return false;
   }
-  if (hasLegacyMouseWheelDelta(ctx.event)) {
+  if (ctx.hasLegacyMouseWheelDelta) {
     return false;
   }
   const peak = Math.max(ctx.absX, ctx.absY);
@@ -348,7 +350,7 @@ function buildWheelSignals(ctx: TWheelContext): TWheelIntentDebugEntry["signals"
     hasFractionalDelta: ctx.hasFractionalDelta,
     isSmallDelta: ctx.isSmallDelta,
     isPixelDeltaMode: ctx.isPixelDeltaMode,
-    hasLegacyMouseWheelDelta: hasLegacyMouseWheelDelta(ctx.event),
+    hasLegacyMouseWheelDelta: ctx.hasLegacyMouseWheelDelta,
   };
 }
 


### PR DESCRIPTION
## Summary

- Fix wheel intent misclassification on **Mac** (Cmd + trackpad scroll now consistently zooms) and **Windows** (legacy `wheelDelta` ±120 mouse wheel no longer treated as trackpad pan during rapid scroll streams)
- Add optional `suppressTextSelection` to drag operations (default `true`) to prevent text selection in React blocks while panning/dragging the camera
- Add **Dev / WheelIntentProbe** Storybook story for capturing and inspecting raw wheel events on real hardware

## Test plan

- [x] `npm test -- wheelIntent.test.ts` — 27 tests pass
- [x] Mac: Cmd + fast trackpad scroll → zoom only (no pan→zoom flip)
- [x] Windows: mouse wheel with `MOUSE_WHEEL_BEHAVIOR: "zoom"` → consistent zoom
- [x] Windows: mouse wheel with `MOUSE_WHEEL_BEHAVIOR: "scroll"` → consistent pan
- [x] Drag camera on canvas over React blocks → no text selection
- [x] Storybook **Dev / WheelIntentProbe** — verify event log and copy-to-clipboard


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Refine wheel intent heuristics for better differentiation between trackpad and mouse wheel across platforms, introduce optional suppression of text selection during drag operations, and add a Storybook dev tool for capturing and inspecting wheel events.

Bug Fixes:
- Correct wheel intent classification on macOS modifier scroll and Chromium/Windows mouse wheels using legacy wheelDelta signals.

Enhancements:
- Improve trackpad vs mouse detection by distinguishing small vs large integer PIXEL deltas and considering rapid scroll streams.
- Adjust pinch-zoom detection to treat all modifier-based PIXEL scroll as zoom while excluding LINE/PAGE mouse-wheel events.
- Extend drag handling to optionally suppress browser text selection during drag sessions, including camera drags over React content.

Documentation:
- Update wheel intent and camera documentation to describe revised heuristics, legacy wheelDelta handling, and new dev probe tooling.

Tests:
- Expand wheel intent unit tests to cover legacy wheelDelta detection, modifier scroll behavior, and Mac Cmd+scroll inertia handling.

Chores:
- Add a Dev/WheelIntentProbe Storybook story, including UI, capture utilities, and styles for live inspection and clipboard export of wheel events and resolver output.