### PR TITLE
fix(wheel): exclude Mac Chrome linear wheelDelta from legacy mouse detection

### DIFF
--- a/docs/system/camera.md
+++ b/docs/system/camera.md
@@ -102,15 +102,43 @@ const graph = new Graph(canvas, {
 - Default: Vertical scrolling (up/down along Y axis)
 - With Shift: Horizontal scrolling (left/right along X axis)
 
+### Wheel input device (`wheelInputDevice`)
+
+Setting on graph **settings** (not camera constants). Tells the resolver how to treat **vertical** wheel input before the camera acts. Works together with `MOUSE_WHEEL_BEHAVIOR`.
+
+```ts
+const graph = new Graph({
+  settings: {
+    wheelInputDevice: "auto", // "auto" | "mouse" | "trackpad" (default: "auto")
+  },
+  constants: {
+    camera: {
+      MOUSE_WHEEL_BEHAVIOR: "zoom",
+    },
+  },
+});
+```
+
+| `wheelInputDevice` | Vertical two-finger / wheel | Pinch (Cmd/Ctrl + scroll) | Horizontal swipe |
+|--------------------|----------------------------|---------------------------|------------------|
+| **`"auto"`** | Inferred: trackpad → pan, mouse → per `MOUSE_WHEEL_BEHAVIOR` | Zoom (`PINCH_ZOOM_SPEED`) | Pan |
+| **`"trackpad"`** | Always **pan** | Zoom | Pan |
+| **`"mouse"`** | Per **`MOUSE_WHEEL_BEHAVIOR`** (`"zoom"` → zoom, `"scroll"` → pan) | Zoom | Pan |
+
+**Camera routing (all modes):**
+
+1. `resolveWheelIntent(event, MOUSE_WHEEL_BEHAVIOR)` → `pan` or `zoom`
+2. **Pan** → `handlePan` (move viewport)
+3. **Zoom** → `handleZoom` at cursor (× `PINCH_ZOOM_SPEED` when pinch gesture)
+
+Full gesture tables, Mac Chrome edge cases, and `I5:sticky-stream`: [Wheel Intent Resolution — Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheelinputdevice).
+
 **Important notes:**
-- `MOUSE_WHEEL_BEHAVIOR` affects **mouse wheel** classification in `resolveWheelIntent` (I4 rules), including large integer PIXEL steps on Chromium (Windows/Edge). Small integer trackpad ticks and rapid-stream trackpad scroll always resolve to pan (I3).
+- `MOUSE_WHEEL_BEHAVIOR` applies only when input is classified as **mouse** (I4 or `wheelInputDevice: "mouse"`). Trackpad vertical scroll always pans.
+- On Mac Chrome/YaBrowser, `"auto"` may confuse trackpads and some mice (both emit integer PIXEL + `wheelDelta ≈ 3×deltaY`). Set `wheelInputDevice` explicitly if needed.
+- Inside a rapid stream (< 38 ms), intent does not flip mid-gesture (`I5:sticky-stream`).
 - Scroll direction switching with Shift is an environment-dependent behavior according to [W3C UI Events specification](https://w3c.github.io/uievents/#events-wheelevents).
-- Different browsers and operating systems may handle Shift+wheel differently.
-- **Trackpad** gestures also pass through `resolveWheelIntent` (see [Wheel Intent Resolution](./wheel-intent.md)):
-  - Two-finger swipe (small integer PIXEL, or large integer in a rapid stream) → pan
-  - Pinch-to-zoom (Ctrl/Cmd + scroll) → zoom with `PINCH_ZOOM_SPEED`
-  - Horizontal / diagonal two-finger swipe → pan (I2)
-- Settings can be updated at runtime using `graph.setConstants()`.
+- Settings can be updated at runtime: `graph.updateSettings({ wheelInputDevice: "trackpad" })`, `graph.setConstants({ camera: { MOUSE_WHEEL_BEHAVIOR: "scroll" } })`.
 
 ### Custom wheel intent classification
 

--- a/docs/system/camera.md
+++ b/docs/system/camera.md
@@ -102,43 +102,41 @@ const graph = new Graph(canvas, {
 - Default: Vertical scrolling (up/down along Y axis)
 - With Shift: Horizontal scrolling (left/right along X axis)
 
-### Wheel input device (`wheelInputDevice`)
+### Wheel input device (`WHEEL_INPUT_DEVICE`)
 
-Setting on graph **settings** (not camera constants). Tells the resolver how to treat **vertical** wheel input before the camera acts. Works together with `MOUSE_WHEEL_BEHAVIOR`.
+Camera **constant** (alongside `MOUSE_WHEEL_BEHAVIOR`). Passed to the resolver on each wheel event. Tells the resolver how to treat **vertical** wheel input before the camera acts.
 
 ```ts
 const graph = new Graph({
-  settings: {
-    wheelInputDevice: "auto", // "auto" | "mouse" | "trackpad" (default: "auto")
-  },
   constants: {
     camera: {
       MOUSE_WHEEL_BEHAVIOR: "zoom",
+      WHEEL_INPUT_DEVICE: "auto", // "auto" | "mouse" | "trackpad" (default: "auto")
     },
   },
 });
 ```
 
-| `wheelInputDevice` | Vertical two-finger / wheel | Pinch (Cmd/Ctrl + scroll) | Horizontal swipe |
-|--------------------|----------------------------|---------------------------|------------------|
+| `WHEEL_INPUT_DEVICE` | Vertical two-finger / wheel | Pinch (Cmd/Ctrl + scroll) | Horizontal swipe |
+|----------------------|----------------------------|---------------------------|------------------|
 | **`"auto"`** | Inferred: trackpad → pan, mouse → per `MOUSE_WHEEL_BEHAVIOR` | Zoom (`PINCH_ZOOM_SPEED`) | Pan |
 | **`"trackpad"`** | Always **pan** | Zoom | Pan |
 | **`"mouse"`** | Per **`MOUSE_WHEEL_BEHAVIOR`** (`"zoom"` → zoom, `"scroll"` → pan) | Zoom | Pan |
 
 **Camera routing (all modes):**
 
-1. `resolveWheelIntent(event, MOUSE_WHEEL_BEHAVIOR)` → `pan` or `zoom`
+1. `resolveWheelIntent(event, { mouseWheelBehavior, wheelInputDevice })` → `pan` or `zoom`
 2. **Pan** → `handlePan` (move viewport)
 3. **Zoom** → `handleZoom` at cursor (× `PINCH_ZOOM_SPEED` when pinch gesture)
 
-Full gesture tables, Mac Chrome edge cases, and `I5:sticky-stream`: [Wheel Intent Resolution — Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheelinputdevice).
+Full gesture tables, Mac Chrome edge cases, and `I5:sticky-stream`: [Wheel Intent Resolution — Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheel_input_device).
 
 **Important notes:**
-- `MOUSE_WHEEL_BEHAVIOR` applies only when input is classified as **mouse** (I4 or `wheelInputDevice: "mouse"`). Trackpad vertical scroll always pans.
-- On Mac Chrome/YaBrowser, `"auto"` may confuse trackpads and some mice (both emit integer PIXEL + `wheelDelta ≈ 3×deltaY`). Set `wheelInputDevice` explicitly if needed.
+- `MOUSE_WHEEL_BEHAVIOR` applies only when input is classified as **mouse** (I4 or `WHEEL_INPUT_DEVICE: "mouse"`). Trackpad vertical scroll always pans.
+- On Mac Chrome/YaBrowser, `"auto"` may confuse trackpads and some mice (both emit integer PIXEL + `wheelDelta ≈ 3×deltaY`). Set `WHEEL_INPUT_DEVICE` explicitly if needed.
 - Inside a rapid stream (< 38 ms), intent does not flip mid-gesture (`I5:sticky-stream`).
 - Scroll direction switching with Shift is an environment-dependent behavior according to [W3C UI Events specification](https://w3c.github.io/uievents/#events-wheelevents).
-- Settings can be updated at runtime: `graph.updateSettings({ wheelInputDevice: "trackpad" })`, `graph.setConstants({ camera: { MOUSE_WHEEL_BEHAVIOR: "scroll" } })`.
+- Constants can be updated at runtime: `graph.setConstants({ camera: { WHEEL_INPUT_DEVICE: "trackpad", MOUSE_WHEEL_BEHAVIOR: "scroll" } })`.
 
 ### Custom wheel intent classification
 
@@ -148,11 +146,11 @@ The camera routes wheel input by **intent** (pan vs zoom). Classification is con
 import { EWheelIntent, createWheelIntentResolver } from "@gravity-ui/graph";
 
 graph.updateSettings({
-  resolveWheelIntent: (event, mouseWheelBehavior) => {
+  resolveWheelIntent: (event, { mouseWheelBehavior, wheelInputDevice }) => {
     // Example: always zoom on vertical wheel
     return EWheelIntent.Zoom;
     // Or use the built-in resolver:
-    // return createWheelIntentResolver()(event, mouseWheelBehavior);
+    // return createWheelIntentResolver()(event, { mouseWheelBehavior, wheelInputDevice });
   },
 });
 ```

--- a/docs/system/wheel-intent.md
+++ b/docs/system/wheel-intent.md
@@ -26,14 +26,28 @@ Resolving **intent directly** from gesture shape:
 resolveWheelIntent: createWheelIntentResolver(),
 ```
 
+Camera passes wheel policy on each call via `TResolveWheelIntentOptions` (from graph constants):
+
+```typescript
+type TResolveWheelIntentOptions = {
+  mouseWheelBehavior: TMouseWheelBehavior;
+  wheelInputDevice?: TWheelInputDevice; // default "auto"
+};
+
+resolveWheelIntent(event, {
+  mouseWheelBehavior: MOUSE_WHEEL_BEHAVIOR,
+  wheelInputDevice: WHEEL_INPUT_DEVICE,
+});
+```
+
 Rules are evaluated in priority order; the first match wins. Debug logs use **rule ids** (column below), which are more specific than the I1–I5 groups.
 
 | Priority | Rule id (debug) | Intent |
 |----------|-----------------|--------|
 | 1 | `I1:pinch` | Zoom |
 | 2 | `I2:horizontal-or-diagonal` | Pan |
-| 3 | `I3:input-device-trackpad` | Pan (when `wheelInputDevice === "trackpad"`) |
-| 4 | `I4:*` via `wheelInputDevice === "mouse"` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
+| 3 | `I3:input-device-trackpad` | Pan (when `WHEEL_INPUT_DEVICE === "trackpad"`) |
+| 4 | `I4:*` via `WHEEL_INPUT_DEVICE === "mouse"` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
 | 5 | `I3:integer-trackpad` / `I3:integer-trackpad-slow` | Pan |
 | 6 | `I4:mouse-wheel-step` / `I4:large-step` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
 | 7 | `I3:rapid-small` / `I4-burst:smoothing` | Pan or Zoom |
@@ -41,7 +55,7 @@ Rules are evaluated in priority order; the first match wins. Debug logs use **ru
 | 9 | `I5:last-intent` | Sticky last intent (default Zoom) |
 | — | `I5:sticky-stream` | Post-pass: keep prior intent inside rapid stream (see I5) |
 
-Rules 3–4 apply only when `wheelInputDevice` is set explicitly; `"auto"` uses rules 5–9. `I5:sticky-stream` runs after the main chain when rapid stream would flip intent.
+Rules 3–4 apply only when `WHEEL_INPUT_DEVICE` is set explicitly; `"auto"` uses rules 5–9. `I5:sticky-stream` runs after the main chain when rapid stream would flip intent.
 
 ---
 
@@ -157,10 +171,10 @@ WheelEvent arrives
 ├─ I2: diagonal OR predominant horizontal?
 │     → Pan
 │
-├─ wheelInputDevice === "trackpad"?
+├─ WHEEL_INPUT_DEVICE === "trackpad"?
 │     → Pan  (I3:input-device-trackpad)
 │
-├─ wheelInputDevice === "mouse"?
+├─ WHEEL_INPUT_DEVICE === "mouse"?
 │     → Pan or Zoom (I4:* per MOUSE_WHEEL_BEHAVIOR)
 │
 ├─ I3: small integer PIXEL, or large integer in rapid stream?
@@ -205,7 +219,7 @@ All magnitude thresholds use pixel-equivalent values after normalization:
 
 ### Fractional delta
 
-Only in PIXEL mode (`deltaMode === 0`). **Integer** raw deltas often indicate trackpad (I3), but Chromium on Windows and some Mac mice also emit integer PIXEL — use legacy `wheelDelta`, timing, and `wheelInputDevice` to disambiguate. **Fractional** PIXEL deltas usually route to mouse (I4), with exceptions for rapid small trackpad inertia (I3:rapid-small). Used for I1 (pinch) and debug signals.
+Only in PIXEL mode (`deltaMode === 0`). **Integer** raw deltas often indicate trackpad (I3), but Chromium on Windows and some Mac mice also emit integer PIXEL — use legacy `wheelDelta`, timing, and `WHEEL_INPUT_DEVICE` to disambiguate. **Fractional** PIXEL deltas usually route to mouse (I4), with exceptions for rapid small trackpad inertia (I3:rapid-small). Used for I1 (pinch) and debug signals.
 
 Checks use **raw values only** — multiplying by DPR before an integer test caused false positives on Windows at non-integer OS scaling (e.g. 110 % → DPR ≈ 1.1).
 
@@ -223,7 +237,10 @@ There is no sticky device session — `I5:last-intent` carries prior classificat
 
 ```typescript
 // Transitional path in Camera.handleWheelEvent:
-const intent = settings.wheelIntentFromEvent(event, MOUSE_WHEEL_BEHAVIOR);
+const intent = settings.wheelIntentFromEvent(event, {
+  mouseWheelBehavior: MOUSE_WHEEL_BEHAVIOR,
+  wheelInputDevice: WHEEL_INPUT_DEVICE,
+});
 
 if (intent === EWheelIntent.Pan) {
   handlePan(event);   // → future: graph event "camera:pan"
@@ -236,13 +253,13 @@ handleZoom(event, acceleration);  // → future: graph event "camera:zoom"
 
 ---
 
-## Wheel input device modes (`wheelInputDevice`)
+## Wheel input device modes (`WHEEL_INPUT_DEVICE`)
 
-The camera does not receive raw hardware type from the browser. It receives a **`WheelEvent`** and asks `resolveWheelIntent` for **pan** or **zoom**. Two settings control the outcome:
+The camera does not receive raw hardware type from the browser. It receives a **`WheelEvent`** and asks `resolveWheelIntent` for **pan** or **zoom**. Two camera constants control the outcome:
 
-| Setting | Where | Role |
-|---------|-------|------|
-| **`wheelInputDevice`** | graph **settings** | How to classify vertical wheel input: infer (`"auto"`), force trackpad, or force mouse |
+| Constant | Where | Role |
+|----------|-------|------|
+| **`WHEEL_INPUT_DEVICE`** | graph **constants** (`camera`) | How to classify vertical wheel input: infer (`"auto"`), force trackpad, or force mouse |
 | **`MOUSE_WHEEL_BEHAVIOR`** | graph **constants** (`camera`) | What vertical **mouse-classified** wheel does: `"zoom"` (default) or `"scroll"` (pan) |
 
 Pinch (Cmd/Ctrl + scroll) and horizontal/diagonal swipes behave the same in all modes — see [I1](#i1--trackpad-modifier-zoom-pinch--cmd--ctrlscroll) and [I2](#i2--horizontal-or-diagonal-movement).
@@ -250,7 +267,10 @@ Pinch (Cmd/Ctrl + scroll) and horizontal/diagonal swipes behave the same in all 
 ### What the camera does after classification
 
 ```typescript
-const intent = settings.wheelIntentFromEvent(event, MOUSE_WHEEL_BEHAVIOR);
+const intent = settings.wheelIntentFromEvent(event, {
+  mouseWheelBehavior: MOUSE_WHEEL_BEHAVIOR,
+  wheelInputDevice: WHEEL_INPUT_DEVICE,
+});
 
 if (intent === EWheelIntent.Pan) {
   handlePan(event); // two-finger swipe, horizontal scroll, mouse scroll when behavior is "scroll"
@@ -331,11 +351,11 @@ Resolver **skips trackpad heuristics** for vertical scroll. Every vertical wheel
               ┌───────────────┴───────────────┐
              yes                              no
               │                                │
-         wheelInputDevice                  Known device
+         WHEEL_INPUT_DEVICE                  Known device
             "auto"                               │
               │                    ┌─────────────┴─────────────┐
               │                 trackpad                    mouse
-              │           wheelInputDevice:            wheelInputDevice:
+              │           WHEEL_INPUT_DEVICE:          WHEEL_INPUT_DEVICE:
               │              "trackpad"                    "mouse"
               │                    │                         │
               └────────────────────┴─────────────────────────┘
@@ -351,22 +371,24 @@ Resolver **skips trackpad heuristics** for vertical scroll. Every vertical wheel
 ```typescript
 // Default — infer device, mouse wheel zooms
 const graph = new Graph({
-  settings: { wheelInputDevice: "auto" },
-  constants: { camera: { MOUSE_WHEEL_BEHAVIOR: "zoom" } },
+  constants: {
+    camera: { MOUSE_WHEEL_BEHAVIOR: "zoom", WHEEL_INPUT_DEVICE: "auto" },
+  },
 });
 
 // Laptop editor — always pan on two-finger swipe
-graph.updateSettings({ wheelInputDevice: "trackpad" });
+graph.setConstants({ camera: { WHEEL_INPUT_DEVICE: "trackpad" } });
 
 // Mouse-only desktop — wheel always zooms (even on Mac Chrome integer deltas)
-graph.updateSettings({ wheelInputDevice: "mouse" });
+graph.setConstants({ camera: { WHEEL_INPUT_DEVICE: "mouse" } });
 
 // Mouse-only but wheel scrolls canvas instead of zooming
-graph.updateSettings({ wheelInputDevice: "mouse" });
-graph.setConstants({ camera: { MOUSE_WHEEL_BEHAVIOR: "scroll" } });
+graph.setConstants({
+  camera: { WHEEL_INPUT_DEVICE: "mouse", MOUSE_WHEEL_BEHAVIOR: "scroll" },
+});
 ```
 
-Changing `wheelInputDevice` via `graph.updateSettings()` recreates the default resolver automatically (unless you also pass a custom `resolveWheelIntent`).
+Changing `WHEEL_INPUT_DEVICE` via `graph.setConstants()` takes effect on the next wheel event — no need to recreate `resolveWheelIntent`.
 
 ---
 
@@ -380,19 +402,19 @@ Trackpad inertia and smooth-scroll mice can both emit small fractional PIXEL del
 
 Trackpad scroll is translated to `WheelEvent` only; `pointerType` stays `"mouse"`. Touch events fire on touchscreens, not trackpads. Intent heuristics remain the only portable tool.
 
-When the app knows the primary wheel device (e.g. desktop app with mouse only, or editor that detects trackpad vs mouse), set graph setting **`wheelInputDevice`**. See [Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheelinputdevice) for full behavior tables.
+When the app knows the primary wheel device (e.g. desktop app with mouse only, or editor that detects trackpad vs mouse), set camera constant **`WHEEL_INPUT_DEVICE`**. See [Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheel_input_device) for full behavior tables.
 
-On Mac Chrome/YaBrowser, trackpads and some high-end mice both emit integer PIXEL deltas with `wheelDelta ≈ 3 × deltaY` — `"auto"` cannot distinguish them. Explicit `wheelInputDevice` fixes that trade-off.
+On Mac Chrome/YaBrowser, trackpads and some high-end mice both emit integer PIXEL deltas with `wheelDelta ≈ 3 × deltaY` — `"auto"` cannot distinguish them. Explicit `WHEEL_INPUT_DEVICE` fixes that trade-off.
 
 ```typescript
 const graph = new Graph({
-  settings: {
-    wheelInputDevice: "mouse", // or "trackpad"
+  constants: {
+    camera: {
+      WHEEL_INPUT_DEVICE: "mouse", // or "trackpad"
+    },
   },
 });
 ```
-
-Changing `wheelInputDevice` via `graph.updateSettings()` recreates the default resolver automatically (unless you also pass a custom `resolveWheelIntent`).
 
 ---
 
@@ -413,7 +435,7 @@ const graph = new Graph({
 
 // Custom resolver:
 graph.updateSettings({
-  resolveWheelIntent: (_event, _mouseWheelBehavior) => EWheelIntent.Zoom,
+  resolveWheelIntent: (_event, _options) => EWheelIntent.Zoom,
 });
 
 // Debug logging (browser console, development builds only):

--- a/docs/system/wheel-intent.md
+++ b/docs/system/wheel-intent.md
@@ -32,11 +32,16 @@ Rules are evaluated in priority order; the first match wins. Debug logs use **ru
 |----------|-----------------|--------|
 | 1 | `I1:pinch` | Zoom |
 | 2 | `I2:horizontal-or-diagonal` | Pan |
-| 3 | `I3:integer-trackpad` / `I3:integer-trackpad-slow` | Pan |
-| 4 | `I4:mouse-wheel-step` / `I4:large-step` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
-| 5 | `I3:rapid-small` / `I4-burst:smoothing` | Pan or Zoom |
-| 6 | `I4:fractional-mouse` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
-| 7 | `I5:last-intent` | Sticky last intent (default Zoom) |
+| 3 | `I3:input-device-trackpad` | Pan (when `wheelInputDevice === "trackpad"`) |
+| 4 | `I4:*` via `wheelInputDevice === "mouse"` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
+| 5 | `I3:integer-trackpad` / `I3:integer-trackpad-slow` | Pan |
+| 6 | `I4:mouse-wheel-step` / `I4:large-step` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
+| 7 | `I3:rapid-small` / `I4-burst:smoothing` | Pan or Zoom |
+| 8 | `I4:fractional-mouse` | Pan or Zoom (`MOUSE_WHEEL_BEHAVIOR`) |
+| 9 | `I5:last-intent` | Sticky last intent (default Zoom) |
+| — | `I5:sticky-stream` | Post-pass: keep prior intent inside rapid stream (see I5) |
+
+Rules 3–4 apply only when `wheelInputDevice` is set explicitly; `"auto"` uses rules 5–9. `I5:sticky-stream` runs after the main chain when rapid stream would flip intent.
 
 ---
 
@@ -50,7 +55,8 @@ Trackpads **always** emit `deltaMode === 0` (`DOM_DELTA_PIXEL`). On Chromium (Ch
 | `deltaMode === 0` + **small integer** `deltaX`/`deltaY` (< 20 px) | **Trackpad** | **Pan** (I3) |
 | `deltaMode === 0` + **large integer** in rapid stream (< 38 ms) | **Trackpad** fast scroll | **Pan** (I3) |
 | `deltaMode === 0` + **isolated large integer** (≥ 20 px, not rapid) | **Mouse** (Chromium) | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
-| `deltaMode === 0` + **legacy wheelDelta ≈ ±120** | **Mouse** (Chromium/Edge) | **I4** (never I3, even in a rapid stream) |
+| `deltaMode === 0` + **legacy wheelDelta ≈ ±120** | **Mouse** (Chromium/Edge on Windows) | **I4** (never I3, even in a rapid stream) |
+| `deltaMode === 0` + **wheelDelta ≈ 3 × deltaY** (Mac Chrome/YaBrowser) | **Trackpad or ambiguous mouse** | **I3** in rapid stream / small steps; not legacy |
 | `deltaMode === 0` + **fractional** deltas | **Mouse** smooth-scroll | **I4** per `MOUSE_WHEEL_BEHAVIOR` |
 
 Integer check uses `Number.isInteger` on raw `deltaX` and `deltaY` (PIXEL mode only).
@@ -103,7 +109,7 @@ Horizontal/diagonal gestures are handled by I2 first.
 | Rapid stream (&lt; 38 ms since previous event) | `I3:integer-trackpad` |
 | Not rapid (small ticks only) | `I3:integer-trackpad-slow` |
 
-Isolated large integer PIXEL steps without legacy `wheelDelta` fall through to **I4** via `isDominantAxisLargeWheel`. Events with **legacy `wheelDelta(Y)` ≈ ±120** (Chromium mechanical mouse on Windows) skip **I3** entirely — including rapid streams (~33 ms apart).
+Isolated large integer PIXEL steps without legacy `wheelDelta` fall through to **I4** via `isDominantAxisLargeWheel`. Events with **legacy `wheelDelta(Y)` ≈ ±120** (Chromium mechanical mouse on Windows) skip **I3** entirely — including rapid streams (~33 ms apart). On Mac Chrome/YaBrowser, `wheelDelta ≈ 3 × deltaY` is **not** treated as legacy (trackpad and some mice share this shape).
 
 ---
 
@@ -136,6 +142,8 @@ Integer PIXEL steps **≥ 20 px** outside a rapid stream are mouse (I4), not I3.
 
 **Intent**: carry forward `lastIntent` (`I5:last-intent`; initial default **Zoom**, aligned with default `MOUSE_WHEEL_BEHAVIOR`)
 
+**Rapid stream sticky** (`I5:sticky-stream`): post-pass after the main chain. When the previous event was **< 38 ms** ago, the newly matched rule would **change** vertical intent, and the previous event was classified by a confident rule (I1–I4, not `I5:last-intent`), keep the prior intent. Pinch (I1) and horizontal/diagonal (I2) always override. Does not apply when the previous rule was `I5:last-intent` (allows trackpad inertia tail to establish pan after an ambiguous first tick).
+
 ---
 
 ## Decision flow
@@ -148,6 +156,12 @@ WheelEvent arrives
 │
 ├─ I2: diagonal OR predominant horizontal?
 │     → Pan
+│
+├─ wheelInputDevice === "trackpad"?
+│     → Pan  (I3:input-device-trackpad)
+│
+├─ wheelInputDevice === "mouse"?
+│     → Pan or Zoom (I4:* per MOUSE_WHEEL_BEHAVIOR)
 │
 ├─ I3: small integer PIXEL, or large integer in rapid stream?
 │     → Pan  (I3:integer-trackpad / I3:integer-trackpad-slow)
@@ -162,6 +176,9 @@ WheelEvent arrives
 │     → Pan or Zoom (MOUSE_WHEEL_BEHAVIOR)
 │
 └─ I5: else → last intent (I5:last-intent)
+     ↓
+   Rapid stream (< 38 ms) and intent would flip?
+     → keep prior intent (I5:sticky-stream); I1/I2 exempt
 ```
 
 ---
@@ -188,7 +205,7 @@ All magnitude thresholds use pixel-equivalent values after normalization:
 
 ### Fractional delta
 
-Only in PIXEL mode (`deltaMode === 0`). **Integer** raw deltas → trackpad pan; **fractional** → mouse (I4). Used for I1 (pinch) and debug signals.
+Only in PIXEL mode (`deltaMode === 0`). **Integer** raw deltas often indicate trackpad (I3), but Chromium on Windows and some Mac mice also emit integer PIXEL — use legacy `wheelDelta`, timing, and `wheelInputDevice` to disambiguate. **Fractional** PIXEL deltas usually route to mouse (I4), with exceptions for rapid small trackpad inertia (I3:rapid-small). Used for I1 (pinch) and debug signals.
 
 Checks use **raw values only** — multiplying by DPR before an integer test caused false positives on Windows at non-integer OS scaling (e.g. 110 % → DPR ≈ 1.1).
 
@@ -198,7 +215,7 @@ Checks use **raw values only** — multiplying by DPR before an integer test cau
 
 **Mouse burst**: **120 ms** after an I4 mouse step; nearby fractional events may follow `I4-burst:smoothing`.
 
-There is no sticky device session — only `I5:last-intent` carries prior classification forward.
+There is no sticky device session — `I5:last-intent` carries prior classification when no rule matches; `I5:sticky-stream` prevents intent flips **inside** a rapid stream (< 38 ms between events).
 
 ---
 
@@ -219,6 +236,140 @@ handleZoom(event, acceleration);  // → future: graph event "camera:zoom"
 
 ---
 
+## Wheel input device modes (`wheelInputDevice`)
+
+The camera does not receive raw hardware type from the browser. It receives a **`WheelEvent`** and asks `resolveWheelIntent` for **pan** or **zoom**. Two settings control the outcome:
+
+| Setting | Where | Role |
+|---------|-------|------|
+| **`wheelInputDevice`** | graph **settings** | How to classify vertical wheel input: infer (`"auto"`), force trackpad, or force mouse |
+| **`MOUSE_WHEEL_BEHAVIOR`** | graph **constants** (`camera`) | What vertical **mouse-classified** wheel does: `"zoom"` (default) or `"scroll"` (pan) |
+
+Pinch (Cmd/Ctrl + scroll) and horizontal/diagonal swipes behave the same in all modes — see [I1](#i1--trackpad-modifier-zoom-pinch--cmd--ctrlscroll) and [I2](#i2--horizontal-or-diagonal-movement).
+
+### What the camera does after classification
+
+```typescript
+const intent = settings.wheelIntentFromEvent(event, MOUSE_WHEEL_BEHAVIOR);
+
+if (intent === EWheelIntent.Pan) {
+  handlePan(event); // two-finger swipe, horizontal scroll, mouse scroll when behavior is "scroll"
+  return;
+}
+
+const acceleration = isPinchZoomGesture(event) ? PINCH_ZOOM_SPEED : 1;
+handleZoom(event, acceleration); // mouse wheel zoom, pinch-to-zoom
+```
+
+| Resolved intent | Camera action | Typical gesture |
+|-----------------|---------------|-----------------|
+| **Pan** | Move viewport (`handlePan`) | Trackpad two-finger swipe, Shift+wheel, horizontal two-finger swipe |
+| **Zoom** | Scale at cursor (`handleZoom`) | Mouse wheel (when `MOUSE_WHEEL_BEHAVIOR: "zoom"`), Cmd/Ctrl + scroll, pinch |
+
+---
+
+### `"auto"` (default)
+
+Resolver **infers** trackpad vs mouse from gesture shape (I3/I4 heuristics). Use when users may switch devices or you cannot detect hardware reliably.
+
+| Gesture | Usual result (`MOUSE_WHEEL_BEHAVIOR: "zoom"`) | Notes |
+|---------|-----------------------------------------------|-------|
+| Trackpad two-finger vertical swipe | **Pan** | Integer PIXEL; fast swipes stay pan in rapid stream |
+| Trackpad horizontal / diagonal swipe | **Pan** | I2 |
+| Trackpad Cmd/Ctrl + scroll (pinch) | **Zoom** | I1; uses `PINCH_ZOOM_SPEED` |
+| Mouse wheel notch (Windows Chromium) | **Zoom** | Integer PIXEL + `wheelDelta ≈ ±120` |
+| Mouse wheel notch (Firefox LINE mode) | **Zoom** | I4 |
+| Smooth-scroll mouse (fractional PIXEL) | **Zoom** | I4 |
+| Mac Chrome trackpad fast swipe | **Pan** | `wheelDelta ≈ 3×deltaY` is not treated as mouse legacy |
+| Mac Chrome high-end mouse (integer + 3×) | **Ambiguous** | Same DOM shape as trackpad — may pan when you expect zoom |
+
+Inside a **rapid stream** (< 38 ms between events), **`I5:sticky-stream`** keeps the intent from the previous tick so one gesture does not flip pan ↔ zoom mid-swipe.
+
+**When to use:** general-purpose graph editors, Storybook demos, mixed input.
+
+---
+
+### `"trackpad"`
+
+Resolver **skips mouse heuristics** for vertical scroll. Every vertical wheel tick → **pan**, except I1/I2.
+
+| Gesture | Camera action |
+|---------|---------------|
+| Two-finger vertical swipe (any speed, any `deltaY`) | **Pan** |
+| Horizontal / diagonal two-finger swipe | **Pan** |
+| Cmd/Ctrl + scroll / pinch | **Zoom** (`PINCH_ZOOM_SPEED`) |
+| Mouse wheel (if user switches device) | **Pan** (vertical ticks forced to trackpad path) |
+
+`MOUSE_WHEEL_BEHAVIOR` does **not** affect vertical trackpad scroll — it always pans.
+
+**When to use:** laptop-first apps, editors where trackpad is the primary input, or Mac Chrome where `"auto"` misclassifies swipes as mouse zoom.
+
+---
+
+### `"mouse"`
+
+Resolver **skips trackpad heuristics** for vertical scroll. Every vertical wheel tick → **I4** → follows **`MOUSE_WHEEL_BEHAVIOR`**.
+
+| Gesture | `MOUSE_WHEEL_BEHAVIOR: "zoom"` | `MOUSE_WHEEL_BEHAVIOR: "scroll"` |
+|---------|------------------------------|----------------------------------|
+| Mouse wheel vertical | **Zoom** | **Pan** |
+| Mouse wheel + Shift | **Pan** (horizontal axis via camera) | **Pan** (horizontal) |
+| Smooth-scroll mouse ramp | **Zoom** | **Pan** |
+| Trackpad two-finger swipe (if user switches device) | **Zoom** | **Pan** |
+| Cmd/Ctrl + scroll on PIXEL delta | **Zoom** | **Zoom** (I1 still wins) |
+| Horizontal / diagonal swipe | **Pan** | **Pan** (I2) |
+
+**When to use:** desktop apps with mouse only, CAD/diagram tools defaulting to wheel zoom, Mac Chrome with high-end mouse that looks like trackpad in `"auto"`.
+
+---
+
+### Choosing a mode
+
+```
+                    Can users switch mouse ↔ trackpad?
+                              │
+              ┌───────────────┴───────────────┐
+             yes                              no
+              │                                │
+         wheelInputDevice                  Known device
+            "auto"                               │
+              │                    ┌─────────────┴─────────────┐
+              │                 trackpad                    mouse
+              │           wheelInputDevice:            wheelInputDevice:
+              │              "trackpad"                    "mouse"
+              │                    │                         │
+              └────────────────────┴─────────────────────────┘
+                              │
+              Still ambiguous on Mac Chrome integer + 3× wheelDelta?
+                              │
+                    Prefer pan → "trackpad"
+                    Prefer zoom → "mouse" + MOUSE_WHEEL_BEHAVIOR: "zoom"
+```
+
+### Configuration examples
+
+```typescript
+// Default — infer device, mouse wheel zooms
+const graph = new Graph({
+  settings: { wheelInputDevice: "auto" },
+  constants: { camera: { MOUSE_WHEEL_BEHAVIOR: "zoom" } },
+});
+
+// Laptop editor — always pan on two-finger swipe
+graph.updateSettings({ wheelInputDevice: "trackpad" });
+
+// Mouse-only desktop — wheel always zooms (even on Mac Chrome integer deltas)
+graph.updateSettings({ wheelInputDevice: "mouse" });
+
+// Mouse-only but wheel scrolls canvas instead of zooming
+graph.updateSettings({ wheelInputDevice: "mouse" });
+graph.setConstants({ camera: { MOUSE_WHEEL_BEHAVIOR: "scroll" } });
+```
+
+Changing `wheelInputDevice` via `graph.updateSettings()` recreates the default resolver automatically (unless you also pass a custom `resolveWheelIntent`).
+
+---
+
 ## Known limitations
 
 ### Ambiguous slow fractional scroll
@@ -228,6 +379,20 @@ Trackpad inertia and smooth-scroll mice can both emit small fractional PIXEL del
 ### PointerEvents / TouchEvents do not help for wheel routing
 
 Trackpad scroll is translated to `WheelEvent` only; `pointerType` stays `"mouse"`. Touch events fire on touchscreens, not trackpads. Intent heuristics remain the only portable tool.
+
+When the app knows the primary wheel device (e.g. desktop app with mouse only, or editor that detects trackpad vs mouse), set graph setting **`wheelInputDevice`**. See [Wheel input device modes](./wheel-intent.md#wheel-input-device-modes-wheelinputdevice) for full behavior tables.
+
+On Mac Chrome/YaBrowser, trackpads and some high-end mice both emit integer PIXEL deltas with `wheelDelta ≈ 3 × deltaY` — `"auto"` cannot distinguish them. Explicit `wheelInputDevice` fixes that trade-off.
+
+```typescript
+const graph = new Graph({
+  settings: {
+    wheelInputDevice: "mouse", // or "trackpad"
+  },
+});
+```
+
+Changing `wheelInputDevice` via `graph.updateSettings()` recreates the default resolver automatically (unless you also pass a custom `resolveWheelIntent`).
 
 ---
 

--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -1,9 +1,14 @@
 import { GraphComponent } from "./components/canvas/GraphComponent";
 import { Block } from "./components/canvas/blocks/Block";
 import { ESelectionStrategy } from "./services/selection";
-import type { TMouseWheelBehavior } from "./utils/functions/wheelIntent";
+import type { TMouseWheelBehavior, TWheelInputDevice } from "./utils/functions/wheelIntent";
 
-export type { TResolveWheelIntent, TWheelInputDevice, TWheelIntentRule } from "./utils/functions/wheelIntent";
+export type {
+  TResolveWheelIntent,
+  TResolveWheelIntentOptions,
+  TWheelInputDevice,
+  TWheelIntentRule,
+} from "./utils/functions/wheelIntent";
 export {
   createWheelIntentResolver,
   enableWheelIntentDebug,
@@ -213,13 +218,22 @@ export type TGraphConstants = {
      * - Integer PIXEL two-finger swipe resolves to pan (I3) — not affected by this constant
      * - Pinch-to-zoom (Cmd/Ctrl + scroll) resolves to zoom with {@link PINCH_ZOOM_SPEED}
      * - Horizontal / diagonal swipe resolves to pan (I2)
-     * - Override ambiguous Mac Chrome input with settings `wheelInputDevice`
+     * - Override ambiguous Mac Chrome input with camera constant `WHEEL_INPUT_DEVICE`
      * - See `docs/system/wheel-intent.md` for classification rules
      *
      * @default "zoom"
      * @see https://w3c.github.io/uievents/#events-wheelevents - W3C UI Events Wheel Events specification
      */
     MOUSE_WHEEL_BEHAVIOR: TMouseWheelBehavior;
+    /**
+     * Explicit primary wheel input device passed to {@link TResolveWheelIntent}.
+     * When `"auto"`, the resolver infers trackpad vs mouse from gesture shape.
+     * Set to `"trackpad"` or `"mouse"` when the app knows the device (e.g. Mac Chrome
+     * where both emit integer PIXEL + linear wheelDelta).
+     *
+     * @default "auto"
+     */
+    WHEEL_INPUT_DEVICE: TWheelInputDevice;
     /**
      * Multiplier for trackpad pinch-to-zoom gesture speed.
      * Applied when zooming with trackpad using pinch gesture (Cmd/Ctrl + scroll).
@@ -291,6 +305,7 @@ export const initGraphConstants: TGraphConstants = {
     AUTO_PAN_THRESHOLD: 50,
     AUTO_PAN_SPEED: 5,
     MOUSE_WHEEL_BEHAVIOR: "zoom",
+    WHEEL_INPUT_DEVICE: "auto",
     PINCH_ZOOM_SPEED: 1,
     PAN_SPEED: 1,
   },

--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -3,8 +3,15 @@ import { Block } from "./components/canvas/blocks/Block";
 import { ESelectionStrategy } from "./services/selection";
 import type { TMouseWheelBehavior } from "./utils/functions/wheelIntent";
 
-export type { TResolveWheelIntent, TWheelInputDevice } from "./utils/functions/wheelIntent";
-export { createWheelIntentResolver, enableWheelIntentDebug, EWheelIntent } from "./utils/functions/wheelIntent";
+export type { TResolveWheelIntent, TWheelInputDevice, TWheelIntentRule } from "./utils/functions/wheelIntent";
+export {
+  createWheelIntentResolver,
+  enableWheelIntentDebug,
+  EWheelIntent,
+  isI3WheelIntentRule,
+  isI4WheelIntentRule,
+  WHEEL_INTENT_RULE,
+} from "./utils/functions/wheelIntent";
 export type { TMouseWheelBehavior };
 
 export type TGraphColors = {

--- a/src/graphConfig.ts
+++ b/src/graphConfig.ts
@@ -3,7 +3,7 @@ import { Block } from "./components/canvas/blocks/Block";
 import { ESelectionStrategy } from "./services/selection";
 import type { TMouseWheelBehavior } from "./utils/functions/wheelIntent";
 
-export type { TResolveWheelIntent } from "./utils/functions/wheelIntent";
+export type { TResolveWheelIntent, TWheelInputDevice } from "./utils/functions/wheelIntent";
 export { createWheelIntentResolver, enableWheelIntentDebug, EWheelIntent } from "./utils/functions/wheelIntent";
 export type { TMouseWheelBehavior };
 
@@ -203,9 +203,10 @@ export type TGraphConstants = {
      * - Different browsers and operating systems may handle Shift+wheel differently
      *
      * **Trackpad behavior (via `resolveWheelIntent`):**
-     * - Integer PIXEL two-finger swipe always resolves to pan (not affected by this constant)
+     * - Integer PIXEL two-finger swipe resolves to pan (I3) — not affected by this constant
      * - Pinch-to-zoom (Cmd/Ctrl + scroll) resolves to zoom with {@link PINCH_ZOOM_SPEED}
-     * - Horizontal / diagonal swipe resolves to pan
+     * - Horizontal / diagonal swipe resolves to pan (I2)
+     * - Override ambiguous Mac Chrome input with settings `wheelInputDevice`
      * - See `docs/system/wheel-intent.md` for classification rules
      *
      * @default "zoom"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,20 @@ export { GraphComponent } from "./components/canvas/GraphComponent";
 export * from "./components/canvas/connections";
 export * from "./graph";
 export type { TGraphColors, TGraphConstants, TMouseWheelBehavior } from "./graphConfig";
-export type { TResolveWheelIntent, TWheelIntentDebugEntry, TWheelInputDevice } from "./utils/functions/wheelIntent";
+export type {
+  TResolveWheelIntent,
+  TWheelIntentDebugEntry,
+  TWheelInputDevice,
+  TWheelIntentRule,
+} from "./utils/functions/wheelIntent";
 export {
   createWheelIntentResolver,
   enableWheelIntentDebug,
   isPinchZoomGesture,
+  isI3WheelIntentRule,
+  isI4WheelIntentRule,
   EWheelIntent,
+  WHEEL_INTENT_RULE,
 } from "./utils/functions/wheelIntent";
 export { type UnwrapGraphEventsDetail, type SelectionEvent } from "./graphEvents";
 export * from "./plugins";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { GraphComponent } from "./components/canvas/GraphComponent";
 export * from "./components/canvas/connections";
 export * from "./graph";
 export type { TGraphColors, TGraphConstants, TMouseWheelBehavior } from "./graphConfig";
-export type { TResolveWheelIntent, TWheelIntentDebugEntry } from "./utils/functions/wheelIntent";
+export type { TResolveWheelIntent, TWheelIntentDebugEntry, TWheelInputDevice } from "./utils/functions/wheelIntent";
 export {
   createWheelIntentResolver,
   enableWheelIntentDebug,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./graph";
 export type { TGraphColors, TGraphConstants, TMouseWheelBehavior } from "./graphConfig";
 export type {
   TResolveWheelIntent,
+  TResolveWheelIntentOptions,
   TWheelIntentDebugEntry,
   TWheelInputDevice,
   TWheelIntentRule,

--- a/src/services/camera/Camera.ts
+++ b/src/services/camera/Camera.ts
@@ -285,10 +285,10 @@ export class Camera extends EventedComponent<TCameraProps, TComponentState, TGra
     event.stopPropagation();
     event.preventDefault();
 
-    const intent = this.context.graph.rootStore.settings.wheelIntentFromEvent(
-      event,
-      this.context.constants.camera.MOUSE_WHEEL_BEHAVIOR
-    );
+    const intent = this.context.graph.rootStore.settings.wheelIntentFromEvent(event, {
+      mouseWheelBehavior: this.context.constants.camera.MOUSE_WHEEL_BEHAVIOR,
+      wheelInputDevice: this.context.constants.camera.WHEEL_INPUT_DEVICE,
+    });
 
     if (intent === EWheelIntent.Pan) {
       this.handlePan(event);

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -6,7 +6,12 @@ import { BlockConnection } from "../components/canvas/connections/BlockConnectio
 import { Component } from "../lib";
 import { defaultGetCameraBlockScaleLevel } from "../services/camera/defaultGetCameraBlockScaleLevel";
 import type { TGetCameraBlockScaleLevel } from "../services/camera/defaultGetCameraBlockScaleLevel";
-import type { EWheelIntent, TMouseWheelBehavior, TResolveWheelIntent } from "../utils/functions/wheelIntent";
+import type {
+  EWheelIntent,
+  TMouseWheelBehavior,
+  TResolveWheelIntent,
+  TWheelInputDevice,
+} from "../utils/functions/wheelIntent";
 import { createWheelIntentResolver } from "../utils/functions/wheelIntent";
 
 import { TConnection } from "./connection/ConnectionState";
@@ -66,6 +71,14 @@ export type TGraphSettingsConfig<Block extends TBlock = TBlock, Connection exten
    */
   emulateMouseEventsOnCameraChange?: boolean;
   /**
+   * Explicit primary wheel input device. When `"auto"`, {@link resolveWheelIntent} infers
+   * trackpad vs mouse from gesture shape. Set to `"trackpad"` or `"mouse"` when the app
+   * knows the device (e.g. Mac Chrome where both emit integer PIXEL + linear wheelDelta).
+   *
+   * @default "auto"
+   */
+  wheelInputDevice?: TWheelInputDevice;
+  /**
    * Classifies wheel input as pan or zoom intent so Camera can route without knowing device type.
    * Also receives `mouseWheelBehavior` so mouse-wheel policy stays in the input layer, not Camera.
    *
@@ -98,6 +111,7 @@ export const DefaultSettings: TGraphSettingsConfig = {
   connectivityComponentOnClickRaise: true,
   showConnectionLabels: false,
   blockComponents: {},
+  wheelInputDevice: "auto",
   resolveWheelIntent: createWheelIntentResolver(),
   getCameraBlockScaleLevel: defaultGetCameraBlockScaleLevel,
 };
@@ -121,6 +135,13 @@ export class GraphEditorSettings {
 
   public setupSettings(config: Partial<TGraphSettingsConfig>) {
     const merged = Object.assign({}, this.$settings.value, config);
+    const wheelInputDevice = merged.wheelInputDevice ?? "auto";
+    merged.wheelInputDevice = wheelInputDevice;
+
+    if (config.wheelInputDevice !== undefined && config.resolveWheelIntent === undefined) {
+      merged.resolveWheelIntent = createWheelIntentResolver({ inputDevice: wheelInputDevice });
+    }
+
     this.$settings.value = {
       ...merged,
       getCameraBlockScaleLevel: merged.getCameraBlockScaleLevel ?? defaultGetCameraBlockScaleLevel,

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -6,12 +6,7 @@ import { BlockConnection } from "../components/canvas/connections/BlockConnectio
 import { Component } from "../lib";
 import { defaultGetCameraBlockScaleLevel } from "../services/camera/defaultGetCameraBlockScaleLevel";
 import type { TGetCameraBlockScaleLevel } from "../services/camera/defaultGetCameraBlockScaleLevel";
-import type {
-  EWheelIntent,
-  TMouseWheelBehavior,
-  TResolveWheelIntent,
-  TWheelInputDevice,
-} from "../utils/functions/wheelIntent";
+import type { EWheelIntent, TResolveWheelIntent, TResolveWheelIntentOptions } from "../utils/functions/wheelIntent";
 import { createWheelIntentResolver } from "../utils/functions/wheelIntent";
 
 import { TConnection } from "./connection/ConnectionState";
@@ -71,16 +66,9 @@ export type TGraphSettingsConfig<Block extends TBlock = TBlock, Connection exten
    */
   emulateMouseEventsOnCameraChange?: boolean;
   /**
-   * Explicit primary wheel input device. When `"auto"`, {@link resolveWheelIntent} infers
-   * trackpad vs mouse from gesture shape. Set to `"trackpad"` or `"mouse"` when the app
-   * knows the device (e.g. Mac Chrome where both emit integer PIXEL + linear wheelDelta).
-   *
-   * @default "auto"
-   */
-  wheelInputDevice?: TWheelInputDevice;
-  /**
    * Classifies wheel input as pan or zoom intent so Camera can route without knowing device type.
-   * Also receives `mouseWheelBehavior` so mouse-wheel policy stays in the input layer, not Camera.
+   * Receives `mouseWheelBehavior` and `wheelInputDevice` from camera constants so wheel policy
+   * stays in the input layer, not Camera.
    *
    * Transitional: today Camera calls {@link GraphEditorSettings.wheelIntentFromEvent} from a raw
    * `wheel` listener. A future input layer will normalize DOM events and emit semantic graph events
@@ -111,7 +99,6 @@ export const DefaultSettings: TGraphSettingsConfig = {
   connectivityComponentOnClickRaise: true,
   showConnectionLabels: false,
   blockComponents: {},
-  wheelInputDevice: "auto",
   resolveWheelIntent: createWheelIntentResolver(),
   getCameraBlockScaleLevel: defaultGetCameraBlockScaleLevel,
 };
@@ -135,12 +122,6 @@ export class GraphEditorSettings {
 
   public setupSettings(config: Partial<TGraphSettingsConfig>) {
     const merged = Object.assign({}, this.$settings.value, config);
-    const wheelInputDevice = merged.wheelInputDevice ?? "auto";
-    merged.wheelInputDevice = wheelInputDevice;
-
-    if (config.wheelInputDevice !== undefined && config.resolveWheelIntent === undefined) {
-      merged.resolveWheelIntent = createWheelIntentResolver({ inputDevice: wheelInputDevice });
-    }
 
     this.$settings.value = {
       ...merged,
@@ -161,8 +142,8 @@ export class GraphEditorSettings {
   /**
    * Resolves wheel intent using {@link TGraphSettingsConfig.resolveWheelIntent} (typed; prefer over getConfigFlag).
    */
-  public wheelIntentFromEvent(event: WheelEvent, mouseWheelBehavior: TMouseWheelBehavior): EWheelIntent {
-    return this.$settings.value.resolveWheelIntent(event, mouseWheelBehavior);
+  public wheelIntentFromEvent(event: WheelEvent, options: TResolveWheelIntentOptions): EWheelIntent {
+    return this.$settings.value.resolveWheelIntent(event, options);
   }
 
   public $connectionsSettings = computed(() => {

--- a/src/stories/examples/mouseWheelBehaviorScroll/mouseWheelBehaviorScroll.stories.tsx
+++ b/src/stories/examples/mouseWheelBehaviorScroll/mouseWheelBehaviorScroll.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-webpack5";
 
 import { TBlock } from "../../../components/canvas/blocks/Block";
 import { Graph, GraphState } from "../../../graph";
-import type { TMouseWheelBehavior } from "../../../graphConfig";
+import type { TMouseWheelBehavior, TWheelInputDevice } from "../../../graphConfig";
 import { EWheelIntent, createWheelIntentResolver } from "../../../graphConfig";
 import { GraphBlock, GraphCanvas, HookGraphParams, useGraph, useGraphEvent } from "../../../react-components";
 import { useFn } from "../../../react-components/utils/hooks/useFn";
@@ -34,12 +34,17 @@ const INTENT_LABEL: Record<EWheelIntent, string> = {
 type MouseWheelBehaviorStoryProps = {
   /** Camera constant: vertical wheel when input is classified as mouse wheel. */
   mouseWheelBehavior: TMouseWheelBehavior;
+  /** Graph setting: explicit wheel device when auto heuristics are ambiguous. */
+  wheelInputDevice: TWheelInputDevice;
 };
 
-function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior }: MouseWheelBehaviorStoryProps) {
+function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior, wheelInputDevice }: MouseWheelBehaviorStoryProps) {
   const [resolvedWheelIntent, setResolvedWheelIntent] = useState<EWheelIntent | null>(null);
 
-  const baseResolveWheelIntent = useMemo(() => createWheelIntentResolver(), []);
+  const baseResolveWheelIntent = useMemo(
+    () => createWheelIntentResolver({ inputDevice: wheelInputDevice }),
+    [wheelInputDevice]
+  );
 
   const graphParams = useMemo<HookGraphParams>(
     () => ({
@@ -52,6 +57,7 @@ function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior }: MouseWheelBeh
       },
       settings: {
         ...GRAPH_SETTINGS,
+        wheelInputDevice,
         resolveWheelIntent: (event: WheelEvent, wb: TMouseWheelBehavior) => {
           const intent = baseResolveWheelIntent(event, wb);
           setResolvedWheelIntent(intent);
@@ -59,14 +65,14 @@ function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior }: MouseWheelBeh
         },
       },
     }),
-    [mouseWheelBehavior, baseResolveWheelIntent]
+    [mouseWheelBehavior, wheelInputDevice, baseResolveWheelIntent]
   );
 
   const { graph, setEntities, start } = useGraph(graphParams);
 
   useEffect(() => {
     setResolvedWheelIntent(null);
-  }, [mouseWheelBehavior]);
+  }, [mouseWheelBehavior, wheelInputDevice]);
 
   useGraphEvent(graph, "state-change", ({ state }) => {
     if (state === GraphState.ATTACHED) {
@@ -132,8 +138,9 @@ function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior }: MouseWheelBeh
           }}
         >
           <Text variant={"body-2"}>
-            <strong>MOUSE_WHEEL_BEHAVIOR</strong> (constants): <strong>{mouseWheelBehavior}</strong> — change via
-            Storybook Controls
+            <strong>MOUSE_WHEEL_BEHAVIOR</strong> (constants): <strong>{mouseWheelBehavior}</strong> ·{" "}
+            <strong>wheelInputDevice</strong> (settings): <strong>{wheelInputDevice}</strong> — change via Storybook
+            Controls
           </Text>
           <Text variant={"body-2"} color={"secondary"}>
             <strong>Resolved wheel intent</strong> (from <code>resolveWheelIntent</code> / heuristics):{" "}
@@ -165,9 +172,15 @@ const meta: Meta<typeof GraphWithMouseWheelBehaviorScroll> = {
       description:
         "Camera constant MOUSE_WHEEL_BEHAVIOR: pan vs zoom for ambiguous mouse-wheel gestures (see resolveWheelIntent I4).",
     },
+    wheelInputDevice: {
+      control: "select",
+      options: ["auto", "mouse", "trackpad"],
+      description: "Graph setting wheelInputDevice: force mouse or trackpad classification instead of auto heuristics.",
+    },
   },
   args: {
     mouseWheelBehavior: "scroll",
+    wheelInputDevice: "auto",
   },
 };
 

--- a/src/stories/examples/mouseWheelBehaviorScroll/mouseWheelBehaviorScroll.stories.tsx
+++ b/src/stories/examples/mouseWheelBehaviorScroll/mouseWheelBehaviorScroll.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-webpack5";
 import { TBlock } from "../../../components/canvas/blocks/Block";
 import { Graph, GraphState } from "../../../graph";
 import type { TMouseWheelBehavior, TWheelInputDevice } from "../../../graphConfig";
-import { EWheelIntent, createWheelIntentResolver } from "../../../graphConfig";
+import { EWheelIntent, enableWheelIntentDebug } from "../../../graphConfig";
 import { GraphBlock, GraphCanvas, HookGraphParams, useGraph, useGraphEvent } from "../../../react-components";
 import { useFn } from "../../../react-components/utils/hooks/useFn";
 import { ECanDrag } from "../../../store/settings";
@@ -34,17 +34,12 @@ const INTENT_LABEL: Record<EWheelIntent, string> = {
 type MouseWheelBehaviorStoryProps = {
   /** Camera constant: vertical wheel when input is classified as mouse wheel. */
   mouseWheelBehavior: TMouseWheelBehavior;
-  /** Graph setting: explicit wheel device when auto heuristics are ambiguous. */
+  /** Camera constant: explicit wheel device when auto heuristics are ambiguous. */
   wheelInputDevice: TWheelInputDevice;
 };
 
 function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior, wheelInputDevice }: MouseWheelBehaviorStoryProps) {
   const [resolvedWheelIntent, setResolvedWheelIntent] = useState<EWheelIntent | null>(null);
-
-  const baseResolveWheelIntent = useMemo(
-    () => createWheelIntentResolver({ inputDevice: wheelInputDevice }),
-    [wheelInputDevice]
-  );
 
   const graphParams = useMemo<HookGraphParams>(
     () => ({
@@ -52,23 +47,25 @@ function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior, wheelInputDevic
         constants: {
           camera: {
             MOUSE_WHEEL_BEHAVIOR: mouseWheelBehavior,
+            WHEEL_INPUT_DEVICE: wheelInputDevice,
           },
         },
       },
-      settings: {
-        ...GRAPH_SETTINGS,
-        wheelInputDevice,
-        resolveWheelIntent: (event: WheelEvent, wb: TMouseWheelBehavior) => {
-          const intent = baseResolveWheelIntent(event, wb);
-          setResolvedWheelIntent(intent);
-          return intent;
-        },
-      },
+      settings: GRAPH_SETTINGS,
     }),
-    [mouseWheelBehavior, wheelInputDevice, baseResolveWheelIntent]
+    [mouseWheelBehavior, wheelInputDevice]
   );
 
   const { graph, setEntities, start } = useGraph(graphParams);
+
+  useEffect(() => {
+    enableWheelIntentDebug((entry) => {
+      setResolvedWheelIntent(entry.result);
+    });
+    return () => {
+      enableWheelIntentDebug(null);
+    };
+  }, []);
 
   useEffect(() => {
     setResolvedWheelIntent(null);
@@ -139,7 +136,7 @@ function GraphWithMouseWheelBehaviorScroll({ mouseWheelBehavior, wheelInputDevic
         >
           <Text variant={"body-2"}>
             <strong>MOUSE_WHEEL_BEHAVIOR</strong> (constants): <strong>{mouseWheelBehavior}</strong> ·{" "}
-            <strong>wheelInputDevice</strong> (settings): <strong>{wheelInputDevice}</strong> — change via Storybook
+            <strong>WHEEL_INPUT_DEVICE</strong> (constants): <strong>{wheelInputDevice}</strong> — change via Storybook
             Controls
           </Text>
           <Text variant={"body-2"} color={"secondary"}>
@@ -175,7 +172,8 @@ const meta: Meta<typeof GraphWithMouseWheelBehaviorScroll> = {
     wheelInputDevice: {
       control: "select",
       options: ["auto", "mouse", "trackpad"],
-      description: "Graph setting wheelInputDevice: force mouse or trackpad classification instead of auto heuristics.",
+      description:
+        "Camera constant WHEEL_INPUT_DEVICE: force mouse or trackpad classification instead of auto heuristics.",
     },
   },
   args: {

--- a/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
+++ b/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
@@ -12,6 +12,7 @@ const MAX_ENTRIES_CAP = 500;
 type TWheelEventLogPanelProps = {
   entries: TWheelProbeLogEntry[];
   mouseWheelBehavior: string;
+  wheelInputDevice: string;
   paused: boolean;
   onPausedChange: (paused: boolean) => void;
   onClear: () => void;
@@ -20,6 +21,7 @@ type TWheelEventLogPanelProps = {
 export function WheelEventLogPanel({
   entries,
   mouseWheelBehavior,
+  wheelInputDevice,
   paused,
   onPausedChange,
   onClear,
@@ -147,8 +149,8 @@ export function WheelEventLogPanel({
           <code>WheelEvent</code> plus <code>resolveWheelIntent</code> output.
         </Text>
         <Text variant="caption-2" color="secondary">
-          Platform: {platformHint} · MOUSE_WHEEL_BEHAVIOR: <strong>{mouseWheelBehavior}</strong> · {entries.length}{" "}
-          events (max {MAX_ENTRIES_CAP})
+          Platform: {platformHint} · MOUSE_WHEEL_BEHAVIOR: <strong>{mouseWheelBehavior}</strong> · wheelInputDevice:{" "}
+          <strong>{wheelInputDevice}</strong> · {entries.length} events (max {MAX_ENTRIES_CAP})
         </Text>
       </Flex>
 

--- a/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
+++ b/src/stories/examples/wheelIntentProbe/WheelEventLogPanel.tsx
@@ -149,7 +149,7 @@ export function WheelEventLogPanel({
           <code>WheelEvent</code> plus <code>resolveWheelIntent</code> output.
         </Text>
         <Text variant="caption-2" color="secondary">
-          Platform: {platformHint} · MOUSE_WHEEL_BEHAVIOR: <strong>{mouseWheelBehavior}</strong> · wheelInputDevice:{" "}
+          Platform: {platformHint} · MOUSE_WHEEL_BEHAVIOR: <strong>{mouseWheelBehavior}</strong> · WHEEL_INPUT_DEVICE:{" "}
           <strong>{wheelInputDevice}</strong> · {entries.length} events (max {MAX_ENTRIES_CAP})
         </Text>
       </Flex>

--- a/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
+++ b/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react-webpack5";
 
 import { TBlock } from "../../../components/canvas/blocks/Block";
 import { Graph, GraphState } from "../../../graph";
-import type { TMouseWheelBehavior } from "../../../graphConfig";
+import type { TMouseWheelBehavior, TWheelInputDevice } from "../../../graphConfig";
 import { createWheelIntentResolver, enableWheelIntentDebug } from "../../../graphConfig";
 import { GraphBlock, GraphCanvas, HookGraphParams, useGraph, useGraphEvent } from "../../../react-components";
 import { useFn } from "../../../react-components/utils/hooks/useFn";
@@ -33,9 +33,13 @@ const GRAPH_SETTINGS: NonNullable<HookGraphParams["settings"]> = {
 
 type WheelIntentProbeStoryProps = {
   mouseWheelBehavior: TMouseWheelBehavior;
+  wheelInputDevice: TWheelInputDevice;
 };
 
-function WheelIntentProbeStory({ mouseWheelBehavior }: WheelIntentProbeStoryProps): React.ReactElement {
+function WheelIntentProbeStory({
+  mouseWheelBehavior,
+  wheelInputDevice,
+}: WheelIntentProbeStoryProps): React.ReactElement {
   const [entries, setEntries] = useState<TWheelProbeLogEntry[]>([]);
   const [paused, setPaused] = useState(false);
   const nextIdRef = useRef(1);
@@ -46,7 +50,10 @@ function WheelIntentProbeStory({ mouseWheelBehavior }: WheelIntentProbeStoryProp
     pausedRef.current = paused;
   }, [paused]);
 
-  const baseResolveWheelIntent = useMemo(() => createWheelIntentResolver(), []);
+  const baseResolveWheelIntent = useMemo(
+    () => createWheelIntentResolver({ inputDevice: wheelInputDevice }),
+    [wheelInputDevice]
+  );
 
   const graphParams = useMemo<HookGraphParams>(
     () => ({
@@ -59,13 +66,14 @@ function WheelIntentProbeStory({ mouseWheelBehavior }: WheelIntentProbeStoryProp
       },
       settings: {
         ...GRAPH_SETTINGS,
+        wheelInputDevice,
         resolveWheelIntent: (event: WheelEvent, wb: TMouseWheelBehavior) => {
           pendingRawRef.current = snapshotRawWheelEvent(event);
           return baseResolveWheelIntent(event, wb);
         },
       },
     }),
-    [mouseWheelBehavior, baseResolveWheelIntent]
+    [mouseWheelBehavior, wheelInputDevice, baseResolveWheelIntent]
   );
 
   const { graph, setEntities, start } = useGraph(graphParams);
@@ -155,6 +163,7 @@ function WheelIntentProbeStory({ mouseWheelBehavior }: WheelIntentProbeStoryProp
           <WheelEventLogPanel
             entries={entries}
             mouseWheelBehavior={mouseWheelBehavior}
+            wheelInputDevice={wheelInputDevice}
             paused={paused}
             onPausedChange={setPaused}
             onClear={() => setEntries([])}
@@ -183,9 +192,15 @@ const meta: Meta<typeof WheelIntentProbeStory> = {
       options: ["scroll", "zoom"],
       description: "MOUSE_WHEEL_BEHAVIOR constant passed to the resolver.",
     },
+    wheelInputDevice: {
+      control: "select",
+      options: ["auto", "mouse", "trackpad"],
+      description: "Graph setting wheelInputDevice: skip ambiguous heuristics when set to mouse or trackpad.",
+    },
   },
   args: {
     mouseWheelBehavior: "zoom",
+    wheelInputDevice: "auto",
   },
 };
 

--- a/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
+++ b/src/stories/examples/wheelIntentProbe/wheelIntentProbe.stories.tsx
@@ -50,10 +50,7 @@ function WheelIntentProbeStory({
     pausedRef.current = paused;
   }, [paused]);
 
-  const baseResolveWheelIntent = useMemo(
-    () => createWheelIntentResolver({ inputDevice: wheelInputDevice }),
-    [wheelInputDevice]
-  );
+  const baseResolveWheelIntent = useMemo(() => createWheelIntentResolver(), []);
 
   const graphParams = useMemo<HookGraphParams>(
     () => ({
@@ -61,15 +58,15 @@ function WheelIntentProbeStory({
         constants: {
           camera: {
             MOUSE_WHEEL_BEHAVIOR: mouseWheelBehavior,
+            WHEEL_INPUT_DEVICE: wheelInputDevice,
           },
         },
       },
       settings: {
         ...GRAPH_SETTINGS,
-        wheelInputDevice,
-        resolveWheelIntent: (event: WheelEvent, wb: TMouseWheelBehavior) => {
+        resolveWheelIntent: (event: WheelEvent, options) => {
           pendingRawRef.current = snapshotRawWheelEvent(event);
-          return baseResolveWheelIntent(event, wb);
+          return baseResolveWheelIntent(event, options);
         },
       },
     }),
@@ -195,7 +192,7 @@ const meta: Meta<typeof WheelIntentProbeStory> = {
     wheelInputDevice: {
       control: "select",
       options: ["auto", "mouse", "trackpad"],
-      description: "Graph setting wheelInputDevice: skip ambiguous heuristics when set to mouse or trackpad.",
+      description: "Camera constant WHEEL_INPUT_DEVICE: skip ambiguous heuristics when set to mouse or trackpad.",
     },
   },
   args: {

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -1,4 +1,12 @@
-import { EWheelIntent, createWheelIntentResolver, enableWheelIntentDebug, isPinchZoomGesture } from "./wheelIntent";
+import {
+  EWheelIntent,
+  WHEEL_INTENT_RULE,
+  createWheelIntentResolver,
+  enableWheelIntentDebug,
+  isI3WheelIntentRule,
+  isI4WheelIntentRule,
+  isPinchZoomGesture,
+} from "./wheelIntent";
 import type { TWheelIntentDebugEntry } from "./wheelIntent";
 
 function makeWheelEvent(
@@ -100,7 +108,7 @@ describe("createWheelIntentResolver", () => {
     advanceMs(33);
     expect(tick()).toBe(EWheelIntent.Zoom);
 
-    expect(entries.every((entry) => entry.rule === "I4:mouse-wheel-step")).toBe(true);
+    expect(entries.every((entry) => entry.rule === WHEEL_INTENT_RULE.I4_MOUSE_WHEEL_STEP)).toBe(true);
     expect(entries.every((entry) => entry.result === EWheelIntent.Zoom)).toBe(true);
     expect(entries.every((entry) => entry.signals.hasLegacyMouseWheelDelta)).toBe(true);
   });
@@ -151,7 +159,7 @@ describe("createWheelIntentResolver", () => {
     expect(tick(1)).toBe(EWheelIntent.Pan);
 
     expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
-    expect(entries.every((entry) => entry.rule.startsWith("I3:"))).toBe(true);
+    expect(entries.every((entry) => isI3WheelIntentRule(entry.rule))).toBe(true);
     expect(entries.every((entry) => entry.signals.hasLegacyMouseWheelDelta === false)).toBe(true);
   });
 
@@ -170,7 +178,7 @@ describe("createWheelIntentResolver", () => {
     advanceMs(16);
     expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
 
-    expect(entries[1]?.rule).toBe("I5:sticky-stream");
+    expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I5_STICKY_STREAM);
     expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
   });
 
@@ -208,8 +216,8 @@ describe("createWheelIntentResolver", () => {
     advanceMs(16);
     expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), "zoom")).toBe(EWheelIntent.Pan);
 
-    expect(entries[0]?.rule).toBe("I5:last-intent");
-    expect(entries[1]?.rule).toBe("I3:rapid-small");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I5_LAST_INTENT);
+    expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I3_RAPID_SMALL);
   });
 
   it("integer PIXEL scroll with deltaX noise stays pan in rapid stream", () => {
@@ -231,7 +239,7 @@ describe("createWheelIntentResolver", () => {
     const resolver = createWheelIntentResolver();
     resolver(makeWheelEvent({ deltaY: -4, deltaX: 0 }), "zoom");
 
-    expect(entries[0]?.rule).toBe("I3:integer-trackpad-slow");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD_SLOW);
     expect(entries[0]?.result).toBe(EWheelIntent.Pan);
   });
 
@@ -283,7 +291,7 @@ describe("createWheelIntentResolver", () => {
 
     resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -6.4, deltaX: 0 }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(entries[1]?.rule).toBe("I4-burst:smoothing");
+    expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I4_BURST_SMOOTHING);
     expect(resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom")).toBe(EWheelIntent.Zoom);
   });
 
@@ -314,7 +322,7 @@ describe("createWheelIntentResolver", () => {
     const intent = resolver(makeWheelEvent({ deltaY: -2, ctrlKey: true }), "zoom");
 
     expect(intent).toBe(EWheelIntent.Zoom);
-    expect(entries[0]?.rule).toBe("I1:pinch");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -2, ctrlKey: true }))).toBe(true);
   });
 
@@ -327,8 +335,8 @@ describe("createWheelIntentResolver", () => {
 
     resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -20, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(entries[0]?.rule).toBe("I1:pinch");
-    expect(entries[1]?.rule).toBe("I1:pinch");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
+    expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, metaKey: true }))).toBe(true);
   });
 
@@ -349,7 +357,7 @@ describe("createWheelIntentResolver", () => {
     });
 
     expect(resolver(makeWheelEvent({ deltaY: -100, ctrlKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(entries[0]?.rule).toBe("I1:pinch");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, ctrlKey: true }))).toBe(true);
   });
 
@@ -422,7 +430,7 @@ describe("createWheelIntentResolver", () => {
     const intent = resolver(makeWheelEvent({ deltaY: -2.2, deltaX: 0 }), "zoom");
 
     expect(intent).toBe(EWheelIntent.Pan);
-    expect(entries[1]?.rule).toBe("I5:last-intent");
+    expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I5_LAST_INTENT);
   });
 
   it("LINE mode rapid wheel is mouse (deltaMode !== 0), never trackpad pan", () => {
@@ -451,7 +459,7 @@ describe("createWheelIntentResolver", () => {
     expect(entries[0]?.inputDevice).toBe("auto");
     expect(entries[0]?.signals.isClassicMouseWheelStep).toBe(true);
     expect(entries[0]?.signals.isPixelDeltaMode).toBe(true);
-    expect(entries[0]?.rule).toBe("I4:mouse-wheel-step");
+    expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I4_MOUSE_WHEEL_STEP);
   });
 
   it("inputDevice trackpad forces pan for Mac Chrome integer wheel (expensive mouse / trackpad ambiguity)", () => {
@@ -471,7 +479,7 @@ describe("createWheelIntentResolver", () => {
 
     expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "zoom")).toBe(EWheelIntent.Zoom);
     expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(entries.every((entry) => entry.rule.startsWith("I4"))).toBe(true);
+    expect(entries.every((entry) => isI4WheelIntentRule(entry.rule))).toBe(true);
     expect(entries.every((entry) => entry.inputDevice === "mouse")).toBe(true);
   });
 

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -86,9 +86,13 @@ describe("createWheelIntentResolver", () => {
   it("slow large integer PIXEL step follows MOUSE_WHEEL_BEHAVIOR (Chromium/Windows mouse)", () => {
     const resolver = createWheelIntentResolver();
 
-    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     advanceMs(50);
-    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "scroll")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "scroll" })).toBe(
+      EWheelIntent.Pan
+    );
   });
 
   it("Chromium mouse rapid stream with wheelDelta ±120 stays zoom (Windows log repro)", () => {
@@ -98,7 +102,8 @@ describe("createWheelIntentResolver", () => {
     });
 
     const resolver = createWheelIntentResolver();
-    const tick = (): EWheelIntent => resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom");
+    const tick = (): EWheelIntent =>
+      resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "zoom" });
 
     expect(tick()).toBe(EWheelIntent.Zoom);
     advanceMs(33);
@@ -116,21 +121,21 @@ describe("createWheelIntentResolver", () => {
   it("small integer PIXEL scroll stays pan (trackpad ticks)", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: 1 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: 11 }), "zoom")).toBe(EWheelIntent.Pan);
-    expect(resolver(makeWheelEvent({ deltaY: 20 }), "zoom")).toBe(EWheelIntent.Pan);
-    expect(resolver(makeWheelEvent({ deltaY: -1 }), "zoom")).toBe(EWheelIntent.Pan);
-    expect(resolver(makeWheelEvent({ deltaY: -11 }), "zoom")).toBe(EWheelIntent.Pan);
-    expect(resolver(makeWheelEvent({ deltaY: -20 }), "zoom")).toBe(EWheelIntent.Pan);
+    resolver(makeWheelEvent({ deltaY: 1 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: 11 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: 20 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -1 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -11 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -20 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
   });
 
   it("large integer PIXEL scroll stays pan inside a rapid stream (trackpad)", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    resolver(makeWheelEvent({ deltaY: -13 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -13 }), { mouseWheelBehavior: "zoom" });
     advanceMs(16);
-    expect(resolver(makeWheelEvent({ deltaY: -100 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -100 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
   });
 
   it("Mac Chrome fast trackpad swipe stays pan despite linear wheelDelta (YaBrowser log repro)", () => {
@@ -141,7 +146,7 @@ describe("createWheelIntentResolver", () => {
 
     const resolver = createWheelIntentResolver();
     const tick = (deltaY: number, deltaX = 0): EWheelIntent =>
-      resolver(makeMacChromeTrackpadWheelEvent({ deltaY, deltaX }), "zoom");
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY, deltaX }), { mouseWheelBehavior: "zoom" });
 
     nowMs = 1000;
     expect(tick(5)).toBe(EWheelIntent.Pan);
@@ -172,11 +177,13 @@ describe("createWheelIntentResolver", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
     advanceMs(16);
-    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Pan
+    );
     advanceMs(16);
-    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
 
     expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I5_STICKY_STREAM);
     expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
@@ -186,20 +193,26 @@ describe("createWheelIntentResolver", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
     advanceMs(16);
-    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Pan
+    );
     advanceMs(50);
-    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("rapid stream sticky does not override I1 pinch zoom", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
     advanceMs(16);
-    expect(resolver(makeWheelEvent({ deltaY: -10, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -10, metaKey: true }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("rapid stream sticky does not block pan after I5:last-intent first tick", () => {
@@ -212,9 +225,11 @@ describe("createWheelIntentResolver", () => {
 
     nowMs = 1000;
     // Ambiguous fractional slow tick → I5:last-intent (default zoom), not a confident rule.
-    resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3 }), { mouseWheelBehavior: "zoom" });
     advanceMs(16);
-    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Pan
+    );
 
     expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I5_LAST_INTENT);
     expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I3_RAPID_SMALL);
@@ -223,10 +238,12 @@ describe("createWheelIntentResolver", () => {
   it("integer PIXEL scroll with deltaX noise stays pan in rapid stream", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -4 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -100, deltaX: 2 }), "zoom")).toBe(EWheelIntent.Pan);
-    resolver(makeWheelEvent({ deltaY: -4 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -20, deltaX: 3 }), "zoom")).toBe(EWheelIntent.Pan);
+    resolver(makeWheelEvent({ deltaY: -4 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -100, deltaX: 2 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Pan
+    );
+    resolver(makeWheelEvent({ deltaY: -4 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -20, deltaX: 3 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
   });
 
   it("slow integer scroll uses I3:integer-trackpad-slow rule id", () => {
@@ -237,7 +254,7 @@ describe("createWheelIntentResolver", () => {
 
     nowMs = 1000;
     const resolver = createWheelIntentResolver();
-    resolver(makeWheelEvent({ deltaY: -4, deltaX: 0 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -4, deltaX: 0 }), { mouseWheelBehavior: "zoom" });
 
     expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD_SLOW);
     expect(entries[0]?.result).toBe(EWheelIntent.Pan);
@@ -246,8 +263,8 @@ describe("createWheelIntentResolver", () => {
   it("rapid discrete mouse wheel steps (≥20px fractional) with MOUSE_WHEEL_BEHAVIOR=zoom stay zoom", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom");
-    const intent = resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -25.5 }), { mouseWheelBehavior: "zoom" });
+    const intent = resolver(makeWheelEvent({ deltaY: -25.5 }), { mouseWheelBehavior: "zoom" });
 
     expect(intent).toBe(EWheelIntent.Zoom);
   });
@@ -255,8 +272,8 @@ describe("createWheelIntentResolver", () => {
   it("rapid integer vertical wheel with MOUSE_WHEEL_BEHAVIOR=scroll resolves to pan", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -10 }), "scroll");
-    const intent = resolver(makeWheelEvent({ deltaY: -10 }), "scroll");
+    resolver(makeWheelEvent({ deltaY: -10 }), { mouseWheelBehavior: "scroll" });
+    const intent = resolver(makeWheelEvent({ deltaY: -10 }), { mouseWheelBehavior: "scroll" });
 
     expect(intent).toBe(EWheelIntent.Pan);
   });
@@ -268,17 +285,19 @@ describe("createWheelIntentResolver", () => {
       deltaMode: WheelEvent.DOM_DELTA_LINE,
     });
 
-    resolver(lineEvent, "zoom");
-    expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(lineEvent, { mouseWheelBehavior: "zoom" });
+    expect(resolver(lineEvent, { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Zoom);
     advanceMs(50);
-    expect(resolver(lineEvent, "scroll")).toBe(EWheelIntent.Pan);
+    expect(resolver(lineEvent, { mouseWheelBehavior: "scroll" })).toBe(EWheelIntent.Pan);
   });
 
   it("vertical wheel with deltaX noise stays zoom when vertical dominates (fractional mouse)", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -100.5, deltaX: 2.1 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -120.25, deltaX: -3.4 }), "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(makeWheelEvent({ deltaY: -100.5, deltaX: 2.1 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -120.25, deltaX: -3.4 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("fractional smoothing events after a wheel tick stay zoom in burst", () => {
@@ -289,25 +308,31 @@ describe("createWheelIntentResolver", () => {
 
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -6.4, deltaX: 0 }), "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(makeWheelEvent({ deltaY: -25.5 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -6.4, deltaX: 0 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I4_BURST_SMOOTHING);
-    expect(resolver(makeWheelEvent({ deltaY: -25.5 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -25.5 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Zoom);
   });
 
   it("smooth mouse wheel ramp (fractional deltas) stays zoom", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: 4.000244140625 }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: 34.15283203125 }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(resolver(makeWheelEvent({ deltaY: 153.34228515625 }), "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(makeWheelEvent({ deltaY: 4.000244140625 }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: 34.15283203125 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
+    expect(resolver(makeWheelEvent({ deltaY: 153.34228515625 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("rapid small fractional deltas resolve to pan (trackpad inertia)", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3 }), "zoom");
-    const intent = resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3 }), { mouseWheelBehavior: "zoom" });
+    const intent = resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), { mouseWheelBehavior: "zoom" });
 
     expect(intent).toBe(EWheelIntent.Pan);
   });
@@ -319,7 +344,7 @@ describe("createWheelIntentResolver", () => {
       entries.push(entry);
     });
 
-    const intent = resolver(makeWheelEvent({ deltaY: -2, ctrlKey: true }), "zoom");
+    const intent = resolver(makeWheelEvent({ deltaY: -2, ctrlKey: true }), { mouseWheelBehavior: "zoom" });
 
     expect(intent).toBe(EWheelIntent.Zoom);
     expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
@@ -333,8 +358,10 @@ describe("createWheelIntentResolver", () => {
       entries.push(entry);
     });
 
-    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -20, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -20, metaKey: true }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, metaKey: true }))).toBe(true);
@@ -343,10 +370,14 @@ describe("createWheelIntentResolver", () => {
   it("Mac Cmd+scroll stays zoom through inertia tail (fractional small deltas)", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), "zoom");
-    expect(resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(makeWheelEvent({ deltaY: -100, metaKey: true }), { mouseWheelBehavior: "zoom" });
+    expect(resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3, metaKey: true }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     advanceMs(850);
-    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1, metaKey: true }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("modifier + large integer PIXEL delta resolves to zoom (trackpad Ctrl/Cmd scroll)", () => {
@@ -356,7 +387,9 @@ describe("createWheelIntentResolver", () => {
       entries.push(entry);
     });
 
-    expect(resolver(makeWheelEvent({ deltaY: -100, ctrlKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -100, ctrlKey: true }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     expect(entries[0]?.rule).toBe(WHEEL_INTENT_RULE.I1_PINCH);
     expect(isPinchZoomGesture(makeWheelEvent({ deltaY: -100, ctrlKey: true }))).toBe(true);
   });
@@ -369,50 +402,56 @@ describe("createWheelIntentResolver", () => {
       ctrlKey: true,
     });
 
-    expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(lineEvent, { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Zoom);
     advanceMs(50);
-    expect(resolver(lineEvent, "scroll")).toBe(EWheelIntent.Pan);
+    expect(resolver(lineEvent, { mouseWheelBehavior: "scroll" })).toBe(EWheelIntent.Pan);
   });
 
   it("predominant horizontal scroll resolves to pan", () => {
     const resolver = createWheelIntentResolver();
 
-    const intent = resolver(makeWheelEvent({ deltaX: -10, deltaY: -1 }), "zoom");
+    const intent = resolver(makeWheelEvent({ deltaX: -10, deltaY: -1 }), { mouseWheelBehavior: "zoom" });
     expect(intent).toBe(EWheelIntent.Pan);
   });
 
   it("diagonal scroll resolves to pan regardless of MOUSE_WHEEL_BEHAVIOR", () => {
     const resolver = createWheelIntentResolver();
-    expect(resolver(makeWheelEvent({ deltaX: -5, deltaY: -5 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaX: -5, deltaY: -5 }), { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Pan);
   });
 
   it("slow small fractional mouse notch respects MOUSE_WHEEL_BEHAVIOR=zoom", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
     advanceMs(850);
-    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), { mouseWheelBehavior: "zoom" })).toBe(
+      EWheelIntent.Zoom
+    );
   });
 
   it("slow small fractional mouse notch respects MOUSE_WHEEL_BEHAVIOR=scroll", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), "scroll")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeWheelEvent({ deltaY: -4.000244140625 }), { mouseWheelBehavior: "scroll" })).toBe(
+      EWheelIntent.Pan
+    );
   });
 
   it("slow ambiguous scroll with scroll mode resolves to pan via integer trackpad", () => {
     const resolver = createWheelIntentResolver();
 
-    const intent = resolver(makeWheelEvent({ deltaY: -4, deltaX: 0 }), "scroll");
+    const intent = resolver(makeWheelEvent({ deltaY: -4, deltaX: 0 }), { mouseWheelBehavior: "scroll" });
     expect(intent).toBe(EWheelIntent.Pan);
   });
 
   it("slow ambiguous fractional vertical scroll uses MOUSE_WHEEL_BEHAVIOR=zoom", () => {
     const resolver = createWheelIntentResolver();
 
-    const intent = resolver(makeWheelEvent({ deltaY: -4.5, deltaX: 0 }), "zoom");
+    const intent = resolver(makeWheelEvent({ deltaY: -4.5, deltaX: 0 }), { mouseWheelBehavior: "zoom" });
     expect(intent).toBe(EWheelIntent.Zoom);
   });
 
@@ -425,9 +464,9 @@ describe("createWheelIntentResolver", () => {
     const resolver = createWheelIntentResolver();
 
     nowMs = 1000;
-    resolver(makeWheelEvent({ deltaY: -4.000244140625 }), "scroll");
+    resolver(makeWheelEvent({ deltaY: -4.000244140625 }), { mouseWheelBehavior: "scroll" });
     advanceMs(850);
-    const intent = resolver(makeWheelEvent({ deltaY: -2.2, deltaX: 0 }), "zoom");
+    const intent = resolver(makeWheelEvent({ deltaY: -2.2, deltaX: 0 }), { mouseWheelBehavior: "zoom" });
 
     expect(intent).toBe(EWheelIntent.Pan);
     expect(entries[1]?.rule).toBe(WHEEL_INTENT_RULE.I5_LAST_INTENT);
@@ -440,8 +479,8 @@ describe("createWheelIntentResolver", () => {
       deltaMode: WheelEvent.DOM_DELTA_LINE,
     });
 
-    resolver(lineEvent, "zoom");
-    expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    resolver(lineEvent, { mouseWheelBehavior: "zoom" });
+    expect(resolver(lineEvent, { mouseWheelBehavior: "zoom" })).toBe(EWheelIntent.Zoom);
   });
 
   it("enableWheelIntentDebug emits full resolver input and signals", () => {
@@ -451,7 +490,7 @@ describe("createWheelIntentResolver", () => {
     });
 
     const resolver = createWheelIntentResolver();
-    resolver(makeWheelEvent({ deltaY: -25.5, deltaX: 0 }), "zoom");
+    resolver(makeWheelEvent({ deltaY: -25.5, deltaX: 0 }), { mouseWheelBehavior: "zoom" });
 
     expect(entries).toHaveLength(1);
     expect(entries[0]?.input.deltaY).toBe(-25.5);
@@ -463,10 +502,20 @@ describe("createWheelIntentResolver", () => {
   });
 
   it("inputDevice trackpad forces pan for Mac Chrome integer wheel (expensive mouse / trackpad ambiguity)", () => {
-    const resolver = createWheelIntentResolver({ inputDevice: "trackpad" });
+    const resolver = createWheelIntentResolver();
 
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "zoom")).toBe(EWheelIntent.Pan);
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), {
+        mouseWheelBehavior: "zoom",
+        wheelInputDevice: "trackpad",
+      })
+    ).toBe(EWheelIntent.Pan);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), {
+        mouseWheelBehavior: "zoom",
+        wheelInputDevice: "trackpad",
+      })
+    ).toBe(EWheelIntent.Pan);
   });
 
   it("inputDevice mouse forces zoom for Mac Chrome integer wheel when MOUSE_WHEEL_BEHAVIOR=zoom", () => {
@@ -475,23 +524,43 @@ describe("createWheelIntentResolver", () => {
       entries.push(entry);
     });
 
-    const resolver = createWheelIntentResolver({ inputDevice: "mouse" });
+    const resolver = createWheelIntentResolver();
 
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "zoom")).toBe(EWheelIntent.Zoom);
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), {
+        mouseWheelBehavior: "zoom",
+        wheelInputDevice: "mouse",
+      })
+    ).toBe(EWheelIntent.Zoom);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), {
+        mouseWheelBehavior: "zoom",
+        wheelInputDevice: "mouse",
+      })
+    ).toBe(EWheelIntent.Zoom);
     expect(entries.every((entry) => isI4WheelIntentRule(entry.rule))).toBe(true);
     expect(entries.every((entry) => entry.inputDevice === "mouse")).toBe(true);
   });
 
   it("inputDevice mouse respects MOUSE_WHEEL_BEHAVIOR=scroll", () => {
-    const resolver = createWheelIntentResolver({ inputDevice: "mouse" });
+    const resolver = createWheelIntentResolver();
 
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "scroll")).toBe(EWheelIntent.Pan);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), {
+        mouseWheelBehavior: "scroll",
+        wheelInputDevice: "mouse",
+      })
+    ).toBe(EWheelIntent.Pan);
   });
 
   it("inputDevice trackpad still allows I1 pinch zoom", () => {
-    const resolver = createWheelIntentResolver({ inputDevice: "trackpad" });
+    const resolver = createWheelIntentResolver();
 
-    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -10, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -10, metaKey: true }), {
+        mouseWheelBehavior: "zoom",
+        wheelInputDevice: "trackpad",
+      })
+    ).toBe(EWheelIntent.Zoom);
   });
 });

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -25,6 +25,9 @@ function makeMacChromeTrackpadWheelEvent(
     deltaX: number;
     deltaY: number;
     deltaMode: number;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
   }> = {}
 ): WheelEvent {
   const deltaY = overrides.deltaY ?? 10;

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -19,6 +19,26 @@ function makeWheelEvent(
   });
 }
 
+/** Mac Chrome/YaBrowser trackpad: integer PIXEL deltaY + wheelDeltaY ≈ ∓3 × deltaY. */
+function makeMacChromeTrackpadWheelEvent(
+  overrides: Partial<{
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }> = {}
+): WheelEvent {
+  const deltaY = overrides.deltaY ?? 10;
+  const event = makeWheelEvent({ deltaY, ...overrides });
+  const legacyDelta = -deltaY * 3;
+  Object.defineProperty(event, "wheelDelta", { configurable: true, value: legacyDelta });
+  Object.defineProperty(event, "wheelDeltaY", { configurable: true, value: legacyDelta });
+  Object.defineProperty(event, "wheelDeltaX", {
+    configurable: true,
+    value: (overrides.deltaX ?? 0) > 0 ? -(overrides.deltaX ?? 0) * 3 : 0,
+  });
+  return event;
+}
+
 /** Chromium/Edge on Windows: integer PIXEL deltaY + legacy wheelDeltaY ≈ ∓120. */
 function makeChromiumMouseWheelEvent(
   overrides: Partial<{
@@ -97,6 +117,36 @@ describe("createWheelIntentResolver", () => {
 
     resolver(makeWheelEvent({ deltaY: -20 }), "zoom");
     expect(resolver(makeWheelEvent({ deltaY: -100 }), "zoom")).toBe(EWheelIntent.Pan);
+  });
+
+  it("Mac Chrome fast trackpad swipe stays pan despite linear wheelDelta (YaBrowser log repro)", () => {
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    const resolver = createWheelIntentResolver();
+    const tick = (deltaY: number, deltaX = 0): EWheelIntent =>
+      resolver(makeMacChromeTrackpadWheelEvent({ deltaY, deltaX }), "zoom");
+
+    nowMs = 1000;
+    expect(tick(5)).toBe(EWheelIntent.Pan);
+    advanceMs(32);
+    expect(tick(313, 4)).toBe(EWheelIntent.Pan);
+    advanceMs(8);
+    expect(tick(70)).toBe(EWheelIntent.Pan);
+    advanceMs(8);
+    expect(tick(450)).toBe(EWheelIntent.Pan);
+    advanceMs(8);
+    expect(tick(34)).toBe(EWheelIntent.Pan);
+    advanceMs(8);
+    expect(tick(86)).toBe(EWheelIntent.Pan);
+    advanceMs(8);
+    expect(tick(1)).toBe(EWheelIntent.Pan);
+
+    expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
+    expect(entries.every((entry) => entry.rule.startsWith("I3:"))).toBe(true);
+    expect(entries.every((entry) => entry.signals.hasLegacyMouseWheelDelta === false)).toBe(true);
   });
 
   it("integer PIXEL scroll with deltaX noise stays pan in rapid stream", () => {

--- a/src/utils/functions/wheelIntent.test.ts
+++ b/src/utils/functions/wheelIntent.test.ts
@@ -76,6 +76,7 @@ describe("createWheelIntentResolver", () => {
     const resolver = createWheelIntentResolver();
 
     expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Zoom);
+    advanceMs(50);
     expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "scroll")).toBe(EWheelIntent.Pan);
   });
 
@@ -115,7 +116,9 @@ describe("createWheelIntentResolver", () => {
   it("large integer PIXEL scroll stays pan inside a rapid stream (trackpad)", () => {
     const resolver = createWheelIntentResolver();
 
-    resolver(makeWheelEvent({ deltaY: -20 }), "zoom");
+    nowMs = 1000;
+    resolver(makeWheelEvent({ deltaY: -13 }), "zoom");
+    advanceMs(16);
     expect(resolver(makeWheelEvent({ deltaY: -100 }), "zoom")).toBe(EWheelIntent.Pan);
   });
 
@@ -147,6 +150,63 @@ describe("createWheelIntentResolver", () => {
     expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
     expect(entries.every((entry) => entry.rule.startsWith("I3:"))).toBe(true);
     expect(entries.every((entry) => entry.signals.hasLegacyMouseWheelDelta === false)).toBe(true);
+  });
+
+  it("rapid stream keeps prior intent when heuristics would flip (I5:sticky-stream)", () => {
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    const resolver = createWheelIntentResolver();
+
+    nowMs = 1000;
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    advanceMs(16);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Pan);
+    advanceMs(16);
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+
+    expect(entries[1]?.rule).toBe("I5:sticky-stream");
+    expect(entries.every((entry) => entry.result === EWheelIntent.Pan)).toBe(true);
+  });
+
+  it("rapid stream sticky yields after pause longer than RAPID_STREAM_MS", () => {
+    const resolver = createWheelIntentResolver();
+
+    nowMs = 1000;
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    advanceMs(16);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Pan);
+    advanceMs(50);
+    expect(resolver(makeChromiumMouseWheelEvent({ deltaY: 100 }), "zoom")).toBe(EWheelIntent.Zoom);
+  });
+
+  it("rapid stream sticky does not override I1 pinch zoom", () => {
+    const resolver = createWheelIntentResolver();
+
+    nowMs = 1000;
+    expect(resolver(makeWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+    advanceMs(16);
+    expect(resolver(makeWheelEvent({ deltaY: -10, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
+  });
+
+  it("rapid stream sticky does not block pan after I5:last-intent first tick", () => {
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    const resolver = createWheelIntentResolver();
+
+    nowMs = 1000;
+    // Ambiguous fractional slow tick → I5:last-intent (default zoom), not a confident rule.
+    resolver(makeWheelEvent({ deltaY: -2.5, deltaX: 0.3 }), "zoom");
+    advanceMs(16);
+    expect(resolver(makeWheelEvent({ deltaY: -1.7, deltaX: 0.1 }), "zoom")).toBe(EWheelIntent.Pan);
+
+    expect(entries[0]?.rule).toBe("I5:last-intent");
+    expect(entries[1]?.rule).toBe("I3:rapid-small");
   });
 
   it("integer PIXEL scroll with deltaX noise stays pan in rapid stream", () => {
@@ -199,6 +259,7 @@ describe("createWheelIntentResolver", () => {
 
     resolver(lineEvent, "zoom");
     expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    advanceMs(50);
     expect(resolver(lineEvent, "scroll")).toBe(EWheelIntent.Pan);
   });
 
@@ -298,6 +359,7 @@ describe("createWheelIntentResolver", () => {
     });
 
     expect(resolver(lineEvent, "zoom")).toBe(EWheelIntent.Zoom);
+    advanceMs(50);
     expect(resolver(lineEvent, "scroll")).toBe(EWheelIntent.Pan);
   });
 
@@ -383,8 +445,42 @@ describe("createWheelIntentResolver", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.input.deltaY).toBe(-25.5);
     expect(entries[0]?.mouseWheelBehavior).toBe("zoom");
+    expect(entries[0]?.inputDevice).toBe("auto");
     expect(entries[0]?.signals.isClassicMouseWheelStep).toBe(true);
     expect(entries[0]?.signals.isPixelDeltaMode).toBe(true);
     expect(entries[0]?.rule).toBe("I4:mouse-wheel-step");
+  });
+
+  it("inputDevice trackpad forces pan for Mac Chrome integer wheel (expensive mouse / trackpad ambiguity)", () => {
+    const resolver = createWheelIntentResolver({ inputDevice: "trackpad" });
+
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "zoom")).toBe(EWheelIntent.Pan);
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Pan);
+  });
+
+  it("inputDevice mouse forces zoom for Mac Chrome integer wheel when MOUSE_WHEEL_BEHAVIOR=zoom", () => {
+    const entries: TWheelIntentDebugEntry[] = [];
+    enableWheelIntentDebug((entry) => {
+      entries.push(entry);
+    });
+
+    const resolver = createWheelIntentResolver({ inputDevice: "mouse" });
+
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -13 }), "zoom")).toBe(EWheelIntent.Zoom);
+    expect(entries.every((entry) => entry.rule.startsWith("I4"))).toBe(true);
+    expect(entries.every((entry) => entry.inputDevice === "mouse")).toBe(true);
+  });
+
+  it("inputDevice mouse respects MOUSE_WHEEL_BEHAVIOR=scroll", () => {
+    const resolver = createWheelIntentResolver({ inputDevice: "mouse" });
+
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -111 }), "scroll")).toBe(EWheelIntent.Pan);
+  });
+
+  it("inputDevice trackpad still allows I1 pinch zoom", () => {
+    const resolver = createWheelIntentResolver({ inputDevice: "trackpad" });
+
+    expect(resolver(makeMacChromeTrackpadWheelEvent({ deltaY: -10, metaKey: true }), "zoom")).toBe(EWheelIntent.Zoom);
   });
 });

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -26,6 +26,50 @@ export enum EWheelIntent {
   Zoom = "zoom",
 }
 
+/** Debug rule ids for {@link createWheelIntentResolver} (see `docs/system/wheel-intent.md`). */
+export const WHEEL_INTENT_RULE = {
+  I1_PINCH: "I1:pinch",
+  I2_HORIZONTAL_OR_DIAGONAL: "I2:horizontal-or-diagonal",
+  I3_INPUT_DEVICE_TRACKPAD: "I3:input-device-trackpad",
+  I3_INTEGER_TRACKPAD: "I3:integer-trackpad",
+  I3_INTEGER_TRACKPAD_SLOW: "I3:integer-trackpad-slow",
+  I3_RAPID_SMALL: "I3:rapid-small",
+  I4_MOUSE_WHEEL_STEP: "I4:mouse-wheel-step",
+  I4_LARGE_STEP: "I4:large-step",
+  I4_FRACTIONAL_MOUSE: "I4:fractional-mouse",
+  I4_BURST_SMOOTHING: "I4-burst:smoothing",
+  I4_INPUT_DEVICE_MOUSE: "I4:input-device-mouse",
+  I5_LAST_INTENT: "I5:last-intent",
+  I5_STICKY_STREAM: "I5:sticky-stream",
+} as const;
+
+export type TWheelIntentRule = (typeof WHEEL_INTENT_RULE)[keyof typeof WHEEL_INTENT_RULE];
+
+const WHEEL_INTENT_I3_RULES: ReadonlySet<TWheelIntentRule> = new Set([
+  WHEEL_INTENT_RULE.I3_INPUT_DEVICE_TRACKPAD,
+  WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD,
+  WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD_SLOW,
+  WHEEL_INTENT_RULE.I3_RAPID_SMALL,
+]);
+
+const WHEEL_INTENT_I4_RULES: ReadonlySet<TWheelIntentRule> = new Set([
+  WHEEL_INTENT_RULE.I4_MOUSE_WHEEL_STEP,
+  WHEEL_INTENT_RULE.I4_LARGE_STEP,
+  WHEEL_INTENT_RULE.I4_FRACTIONAL_MOUSE,
+  WHEEL_INTENT_RULE.I4_BURST_SMOOTHING,
+  WHEEL_INTENT_RULE.I4_INPUT_DEVICE_MOUSE,
+]);
+
+/** Returns true when the rule id belongs to trackpad classification (I3). */
+export function isI3WheelIntentRule(rule: TWheelIntentRule): boolean {
+  return WHEEL_INTENT_I3_RULES.has(rule);
+}
+
+/** Returns true when the rule id belongs to mouse-wheel classification (I4). */
+export function isI4WheelIntentRule(rule: TWheelIntentRule): boolean {
+  return WHEEL_INTENT_I4_RULES.has(rule);
+}
+
 /**
  * Classifies a wheel event as pan or zoom intent.
  * Configured as `resolveWheelIntent` on graph settings (`TGraphSettingsConfig`).
@@ -80,7 +124,7 @@ export type TWheelIntentDebugEntry = {
     hasLegacyMouseWheelDelta: boolean;
   };
   /** Winning rule id and resolved intent. */
-  rule: string;
+  rule: TWheelIntentRule;
   result: EWheelIntent;
 };
 
@@ -402,23 +446,23 @@ function intentFromMouseWheelBehavior(mouseWheelBehavior: TMouseWheelBehavior): 
 /** I1/I2 always win; during rapid stream keep prior vertical intent to avoid mid-gesture flips. */
 function applyRapidStreamStickyIntent(
   intent: EWheelIntent,
-  rule: string,
+  rule: TWheelIntentRule,
   signals: TWheelIntentDebugEntry["signals"],
   isRapidStream: boolean,
   lastIntentBefore: EWheelIntent,
-  lastRuleBefore: string
-): { intent: EWheelIntent; rule: string } {
+  lastRuleBefore: TWheelIntentRule
+): { intent: EWheelIntent; rule: TWheelIntentRule } {
   if (
     !isRapidStream ||
     signals.isPinchZoom ||
     signals.isDiagonalScroll ||
     signals.isPredominantHorizontalScroll ||
     intent === lastIntentBefore ||
-    lastRuleBefore === "I5:last-intent"
+    lastRuleBefore === WHEEL_INTENT_RULE.I5_LAST_INTENT
   ) {
     return { intent, rule };
   }
-  return { intent: lastIntentBefore, rule: "I5:sticky-stream" };
+  return { intent: lastIntentBefore, rule: WHEEL_INTENT_RULE.I5_STICKY_STREAM };
 }
 
 function emitDebugEntry(
@@ -431,7 +475,7 @@ function emitDebugEntry(
   mouseWheelBurstRemainingMs: number | null,
   lastIntentBefore: EWheelIntent,
   signals: TWheelIntentDebugEntry["signals"],
-  rule: string,
+  rule: TWheelIntentRule,
   result: EWheelIntent
 ): void {
   const debugLogger = getWheelIntentDebugLogger();
@@ -503,7 +547,7 @@ function emitDebugEntry(
 export function createWheelIntentResolver(options: TCreateWheelIntentResolverOptions = {}): TResolveWheelIntent {
   const inputDevice = options.inputDevice ?? "auto";
   let lastIntent: EWheelIntent = EWheelIntent.Zoom;
-  let lastRule = "I5:last-intent";
+  let lastRule: TWheelIntentRule = WHEEL_INTENT_RULE.I5_LAST_INTENT;
   let lastTimestamp: number | null = null;
   let mouseWheelBurstUntil: number | null = null;
 
@@ -520,32 +564,32 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
     isRapidStream: boolean,
     inMouseWheelBurst: boolean,
     now: number
-  ): { intent: EWheelIntent; rule: string } => {
+  ): { intent: EWheelIntent; rule: TWheelIntentRule } => {
     if (signals.isDominantAxisLargeWheel || signals.isClassicMouseWheelStep || signals.hasLegacyMouseWheelDelta) {
       markMouseWheelBurst(now);
       return {
         intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
-        rule: signals.isClassicMouseWheelStep ? "I4:mouse-wheel-step" : "I4:large-step",
+        rule: signals.isClassicMouseWheelStep ? WHEEL_INTENT_RULE.I4_MOUSE_WHEEL_STEP : WHEEL_INTENT_RULE.I4_LARGE_STEP,
       };
     }
     if (isSlowFractionalMouseWheelStep(ctx, isRapidStream, inMouseWheelBurst)) {
       markMouseWheelBurst(now);
       return {
         intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
-        rule: "I4:fractional-mouse",
+        rule: WHEEL_INTENT_RULE.I4_FRACTIONAL_MOUSE,
       };
     }
     if (inMouseWheelBurst && signals.isVerticalOnly && isTrackpadLikeRapidSmall(ctx, isRapidStream)) {
       markMouseWheelBurst(now);
       return {
         intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
-        rule: "I4-burst:smoothing",
+        rule: WHEEL_INTENT_RULE.I4_BURST_SMOOTHING,
       };
     }
     markMouseWheelBurst(now);
     return {
       intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
-      rule: "I4:input-device-mouse",
+      rule: WHEEL_INTENT_RULE.I4_INPUT_DEVICE_MOUSE,
     };
   };
 
@@ -564,17 +608,17 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
     const lastRuleBefore = lastRule;
 
     let intent: EWheelIntent;
-    let rule: string;
+    let rule: TWheelIntentRule;
 
     if (signals.isPinchZoom) {
       intent = EWheelIntent.Zoom;
-      rule = "I1:pinch";
+      rule = WHEEL_INTENT_RULE.I1_PINCH;
     } else if (signals.isDiagonalScroll || signals.isPredominantHorizontalScroll) {
       intent = EWheelIntent.Pan;
-      rule = "I2:horizontal-or-diagonal";
+      rule = WHEEL_INTENT_RULE.I2_HORIZONTAL_OR_DIAGONAL;
     } else if (inputDevice === "trackpad") {
       intent = EWheelIntent.Pan;
-      rule = "I3:input-device-trackpad";
+      rule = WHEEL_INTENT_RULE.I3_INPUT_DEVICE_TRACKPAD;
     } else if (inputDevice === "mouse") {
       ({ intent, rule } = resolveExplicitMouseIntent(
         ctx,
@@ -586,31 +630,31 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
       ));
     } else if (isIntegerPixelTrackpadScroll(ctx, isRapidStream)) {
       intent = EWheelIntent.Pan;
-      rule = isRapidStream ? "I3:integer-trackpad" : "I3:integer-trackpad-slow";
+      rule = isRapidStream ? WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD : WHEEL_INTENT_RULE.I3_INTEGER_TRACKPAD_SLOW;
     } else if (
       signals.isDominantAxisLargeWheel ||
       signals.isClassicMouseWheelStep ||
       signals.hasLegacyMouseWheelDelta
     ) {
       intent = intentFromMouseWheelBehavior(mouseWheelBehavior);
-      rule = signals.isClassicMouseWheelStep ? "I4:mouse-wheel-step" : "I4:large-step";
+      rule = signals.isClassicMouseWheelStep ? WHEEL_INTENT_RULE.I4_MOUSE_WHEEL_STEP : WHEEL_INTENT_RULE.I4_LARGE_STEP;
       markMouseWheelBurst(now);
     } else if (isTrackpadLikeRapidSmall(ctx, isRapidStream)) {
       if (inMouseWheelBurst && signals.isVerticalOnly) {
         intent = intentFromMouseWheelBehavior(mouseWheelBehavior);
-        rule = "I4-burst:smoothing";
+        rule = WHEEL_INTENT_RULE.I4_BURST_SMOOTHING;
         markMouseWheelBurst(now);
       } else {
         intent = EWheelIntent.Pan;
-        rule = "I3:rapid-small";
+        rule = WHEEL_INTENT_RULE.I3_RAPID_SMALL;
       }
     } else if (isSlowFractionalMouseWheelStep(ctx, isRapidStream, inMouseWheelBurst)) {
       intent = intentFromMouseWheelBehavior(mouseWheelBehavior);
-      rule = "I4:fractional-mouse";
+      rule = WHEEL_INTENT_RULE.I4_FRACTIONAL_MOUSE;
       markMouseWheelBurst(now);
     } else {
       intent = lastIntent;
-      rule = "I5:last-intent";
+      rule = WHEEL_INTENT_RULE.I5_LAST_INTENT;
     }
 
     ({ intent, rule } = applyRapidStreamStickyIntent(

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -191,6 +191,10 @@ function normalizeWheelDelta(delta: number, deltaMode: number): number {
 /** Minimum |wheelDelta| / |wheelDeltaY| for legacy mouse-wheel detection (Chromium ≈ 120). */
 const LEGACY_MOUSE_WHEEL_DELTA_MIN = 100;
 
+/** Mac Chrome/YaBrowser trackpad: wheelDeltaY ≈ ±3 × deltaY (not fixed ±120 mouse notch). */
+const MAC_CHROME_TRACKPAD_WHEEL_DELTA_RATIO = 3;
+const MAC_CHROME_TRACKPAD_RATIO_TOLERANCE = 0.35;
+
 type TLegacyWheelEvent = WheelEvent & {
   wheelDelta?: number;
   wheelDeltaX?: number;
@@ -198,8 +202,26 @@ type TLegacyWheelEvent = WheelEvent & {
 };
 
 /**
- * Chromium still sets deprecated wheelDelta( Y ) on mechanical mouse wheels (typically ±120).
- * Trackpad scroll usually omits it or uses smaller values.
+ * True when wheelDeltaY looks like a fixed ±120 mechanical mouse notch (Chromium/Windows).
+ *
+ * Mac Chrome trackpad also populates wheelDelta, but as a linear ±3 × deltaY scale — that must
+ * not be treated as a mouse wheel or fast trackpad swipes fall through to I4 zoom.
+ */
+function isMacChromeLinearWheelDelta(event: WheelEvent, wheelDeltaY: number): boolean {
+  const { deltaY, deltaMode } = event;
+  if (deltaMode !== WheelEvent.DOM_DELTA_PIXEL || deltaY === 0 || !Number.isInteger(deltaY)) {
+    return false;
+  }
+  const ratio = Math.abs(wheelDeltaY / deltaY);
+  return (
+    ratio > MAC_CHROME_TRACKPAD_WHEEL_DELTA_RATIO - MAC_CHROME_TRACKPAD_RATIO_TOLERANCE &&
+    ratio < MAC_CHROME_TRACKPAD_WHEEL_DELTA_RATIO + MAC_CHROME_TRACKPAD_RATIO_TOLERANCE
+  );
+}
+
+/**
+ * Chromium still sets deprecated wheelDelta(Y) on mechanical mouse wheels (typically ±120).
+ * Trackpad scroll on Mac Chrome uses wheelDelta ≈ ±3 × deltaY instead.
  */
 function hasLegacyMouseWheelDelta(event: WheelEvent): boolean {
   const legacy = event as TLegacyWheelEvent;
@@ -207,7 +229,13 @@ function hasLegacyMouseWheelDelta(event: WheelEvent): boolean {
   if (axisDelta === undefined) {
     return false;
   }
-  return Math.abs(axisDelta) >= LEGACY_MOUSE_WHEEL_DELTA_MIN;
+  if (Math.abs(axisDelta) < LEGACY_MOUSE_WHEEL_DELTA_MIN) {
+    return false;
+  }
+  if (isMacChromeLinearWheelDelta(event, axisDelta)) {
+    return false;
+  }
+  return true;
 }
 
 function createWheelContext(event: WheelEvent): TWheelContext {

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -1,5 +1,16 @@
 export type TMouseWheelBehavior = "zoom" | "scroll";
 
+/** Explicit wheel input device; `"auto"` uses gesture-shape heuristics. */
+export type TWheelInputDevice = "auto" | "mouse" | "trackpad";
+
+export type TCreateWheelIntentResolverOptions = {
+  /**
+   * When set to `"trackpad"` or `"mouse"`, skips ambiguous device heuristics
+   * (e.g. Mac Chrome integer PIXEL + linear wheelDelta).
+   */
+  inputDevice?: TWheelInputDevice;
+};
+
 /**
  * Wheel input classification for camera routing.
  *
@@ -25,6 +36,8 @@ export type TResolveWheelIntent = (event: WheelEvent, mouseWheelBehavior: TMouse
 export type TWheelIntentDebugEntry = {
   /** Second argument to {@link TResolveWheelIntent}. */
   mouseWheelBehavior: TMouseWheelBehavior;
+  /** Resolver option when not `"auto"`. */
+  inputDevice: TWheelInputDevice;
   /** Raw {@link WheelEvent} fields passed into the resolver. */
   input: {
     deltaX: number;
@@ -63,7 +76,7 @@ export type TWheelIntentDebugEntry = {
     isSmallDelta: boolean;
     /** Trackpads always emit `deltaMode === DOM_DELTA_PIXEL` (0); mice use LINE/PAGE or PIXEL. */
     isPixelDeltaMode: boolean;
-    /** Deprecated `wheelDelta(Y)` ≈ ±120 on Chromium mechanical mouse wheels. */
+    /** Deprecated `wheelDelta(Y)` ≈ ±120 on Chromium mechanical mouse wheels (Mac Chrome 3× ratio excluded). */
     hasLegacyMouseWheelDelta: boolean;
   };
   /** Winning rule id and resolved intent. */
@@ -386,9 +399,32 @@ function intentFromMouseWheelBehavior(mouseWheelBehavior: TMouseWheelBehavior): 
   return mouseWheelBehavior === "scroll" ? EWheelIntent.Pan : EWheelIntent.Zoom;
 }
 
+/** I1/I2 always win; during rapid stream keep prior vertical intent to avoid mid-gesture flips. */
+function applyRapidStreamStickyIntent(
+  intent: EWheelIntent,
+  rule: string,
+  signals: TWheelIntentDebugEntry["signals"],
+  isRapidStream: boolean,
+  lastIntentBefore: EWheelIntent,
+  lastRuleBefore: string
+): { intent: EWheelIntent; rule: string } {
+  if (
+    !isRapidStream ||
+    signals.isPinchZoom ||
+    signals.isDiagonalScroll ||
+    signals.isPredominantHorizontalScroll ||
+    intent === lastIntentBefore ||
+    lastRuleBefore === "I5:last-intent"
+  ) {
+    return { intent, rule };
+  }
+  return { intent: lastIntentBefore, rule: "I5:sticky-stream" };
+}
+
 function emitDebugEntry(
   ctx: TWheelContext,
   mouseWheelBehavior: TMouseWheelBehavior,
+  inputDevice: TWheelInputDevice,
   timeSinceLastWheel: number,
   isRapidStream: boolean,
   isInMouseWheelBurst: boolean,
@@ -407,6 +443,7 @@ function emitDebugEntry(
 
   debugLogger({
     mouseWheelBehavior,
+    inputDevice,
     input: {
       deltaX: event.deltaX,
       deltaY: event.deltaY,
@@ -444,11 +481,14 @@ function emitDebugEntry(
  * |---------------------------------------|-----------------|
  * | ctrlKey / metaKey + PIXEL scroll       | Zoom (I1)       |
  * | Horizontal or diagonal movement       | Pan  (I2)       |
- * | Integer PIXEL delta (trackpad)        | Pan  (I3)       |
+ * | Integer PIXEL delta (trackpad, auto)   | Pan  (I3)       |
+ * | wheelInputDevice `"trackpad"`         | Pan  (I3:input-device-trackpad) |
+ * | wheelInputDevice `"mouse"`            | Zoom/Pan (I4:* per behavior) |
  * | Large isolated integer PIXEL step     | Zoom/Pan (I4)*  |
  * | Classic mouse wheel step (fractional) | Zoom/Pan (I4)*  |
  * | Rapid stream + small delta (fractional)| Pan  (I3)      |
  * | Anything else                         | Last intent (I5)|
+ * | Rapid stream + confident-rule flip    | Sticky prior (I5:sticky-stream) |
  *
  * *I4 respects `mouseWheelBehavior`: `"scroll"` → Pan, `"zoom"` → Zoom.
  *
@@ -456,9 +496,14 @@ function emitDebugEntry(
  * Isolated large integer PIXEL (Chromium mouse on Windows) → I4 per `mouseWheelBehavior`.
  * LINE/PAGE mode (`deltaMode !== 0`) is never trackpad — always mouse (I4).
  * See `docs/system/wheel-intent.md` for rationale.
+ *
+ * Pass `{ inputDevice: "trackpad" | "mouse" }` when the app knows the primary wheel device
+ * and Mac Chrome/YaBrowser heuristics are ambiguous.
  */
-export function createWheelIntentResolver(): TResolveWheelIntent {
+export function createWheelIntentResolver(options: TCreateWheelIntentResolverOptions = {}): TResolveWheelIntent {
+  const inputDevice = options.inputDevice ?? "auto";
   let lastIntent: EWheelIntent = EWheelIntent.Zoom;
+  let lastRule = "I5:last-intent";
   let lastTimestamp: number | null = null;
   let mouseWheelBurstUntil: number | null = null;
 
@@ -467,6 +512,42 @@ export function createWheelIntentResolver(): TResolveWheelIntent {
   };
 
   const isInMouseWheelBurst = (now: number): boolean => mouseWheelBurstUntil !== null && now <= mouseWheelBurstUntil;
+
+  const resolveExplicitMouseIntent = (
+    ctx: TWheelContext,
+    signals: TWheelIntentDebugEntry["signals"],
+    mouseWheelBehavior: TMouseWheelBehavior,
+    isRapidStream: boolean,
+    inMouseWheelBurst: boolean,
+    now: number
+  ): { intent: EWheelIntent; rule: string } => {
+    if (signals.isDominantAxisLargeWheel || signals.isClassicMouseWheelStep || signals.hasLegacyMouseWheelDelta) {
+      markMouseWheelBurst(now);
+      return {
+        intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
+        rule: signals.isClassicMouseWheelStep ? "I4:mouse-wheel-step" : "I4:large-step",
+      };
+    }
+    if (isSlowFractionalMouseWheelStep(ctx, isRapidStream, inMouseWheelBurst)) {
+      markMouseWheelBurst(now);
+      return {
+        intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
+        rule: "I4:fractional-mouse",
+      };
+    }
+    if (inMouseWheelBurst && signals.isVerticalOnly && isTrackpadLikeRapidSmall(ctx, isRapidStream)) {
+      markMouseWheelBurst(now);
+      return {
+        intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
+        rule: "I4-burst:smoothing",
+      };
+    }
+    markMouseWheelBurst(now);
+    return {
+      intent: intentFromMouseWheelBehavior(mouseWheelBehavior),
+      rule: "I4:input-device-mouse",
+    };
+  };
 
   return (event: WheelEvent, mouseWheelBehavior: TMouseWheelBehavior): EWheelIntent => {
     const now = performance.now();
@@ -480,6 +561,7 @@ export function createWheelIntentResolver(): TResolveWheelIntent {
     const ctx = createWheelContext(event);
     const signals = buildWheelSignals(ctx);
     const lastIntentBefore = lastIntent;
+    const lastRuleBefore = lastRule;
 
     let intent: EWheelIntent;
     let rule: string;
@@ -490,6 +572,18 @@ export function createWheelIntentResolver(): TResolveWheelIntent {
     } else if (signals.isDiagonalScroll || signals.isPredominantHorizontalScroll) {
       intent = EWheelIntent.Pan;
       rule = "I2:horizontal-or-diagonal";
+    } else if (inputDevice === "trackpad") {
+      intent = EWheelIntent.Pan;
+      rule = "I3:input-device-trackpad";
+    } else if (inputDevice === "mouse") {
+      ({ intent, rule } = resolveExplicitMouseIntent(
+        ctx,
+        signals,
+        mouseWheelBehavior,
+        isRapidStream,
+        inMouseWheelBurst,
+        now
+      ));
     } else if (isIntegerPixelTrackpadScroll(ctx, isRapidStream)) {
       intent = EWheelIntent.Pan;
       rule = isRapidStream ? "I3:integer-trackpad" : "I3:integer-trackpad-slow";
@@ -519,11 +613,22 @@ export function createWheelIntentResolver(): TResolveWheelIntent {
       rule = "I5:last-intent";
     }
 
+    ({ intent, rule } = applyRapidStreamStickyIntent(
+      intent,
+      rule,
+      signals,
+      isRapidStream,
+      lastIntentBefore,
+      lastRuleBefore
+    ));
+
     lastIntent = intent;
+    lastRule = rule;
     if (getWheelIntentDebugLogger() !== null) {
       emitDebugEntry(
         ctx,
         mouseWheelBehavior,
+        inputDevice,
         timeSince,
         isRapidStream,
         inMouseWheelBurst,

--- a/src/utils/functions/wheelIntent.ts
+++ b/src/utils/functions/wheelIntent.ts
@@ -3,14 +3,6 @@ export type TMouseWheelBehavior = "zoom" | "scroll";
 /** Explicit wheel input device; `"auto"` uses gesture-shape heuristics. */
 export type TWheelInputDevice = "auto" | "mouse" | "trackpad";
 
-export type TCreateWheelIntentResolverOptions = {
-  /**
-   * When set to `"trackpad"` or `"mouse"`, skips ambiguous device heuristics
-   * (e.g. Mac Chrome integer PIXEL + linear wheelDelta).
-   */
-  inputDevice?: TWheelInputDevice;
-};
-
 /**
  * Wheel input classification for camera routing.
  *
@@ -71,16 +63,24 @@ export function isI4WheelIntentRule(rule: TWheelIntentRule): boolean {
 }
 
 /**
+ * Camera wheel policy passed to {@link TResolveWheelIntent} (from graph constants).
+ */
+export type TResolveWheelIntentOptions = {
+  mouseWheelBehavior: TMouseWheelBehavior;
+  wheelInputDevice?: TWheelInputDevice;
+};
+
+/**
  * Classifies a wheel event as pan or zoom intent.
  * Configured as `resolveWheelIntent` on graph settings (`TGraphSettingsConfig`).
  */
-export type TResolveWheelIntent = (event: WheelEvent, mouseWheelBehavior: TMouseWheelBehavior) => EWheelIntent;
+export type TResolveWheelIntent = (event: WheelEvent, options: TResolveWheelIntentOptions) => EWheelIntent;
 
 /** Snapshot of resolver inputs, derived signals, session state, and the winning rule. */
 export type TWheelIntentDebugEntry = {
-  /** Second argument to {@link TResolveWheelIntent}. */
+  /** {@link TResolveWheelIntentOptions.mouseWheelBehavior}. */
   mouseWheelBehavior: TMouseWheelBehavior;
-  /** Resolver option when not `"auto"`. */
+  /** {@link TResolveWheelIntentOptions.wheelInputDevice} (defaults to `"auto"`). */
   inputDevice: TWheelInputDevice;
   /** Raw {@link WheelEvent} fields passed into the resolver. */
   input: {
@@ -541,11 +541,10 @@ function emitDebugEntry(
  * LINE/PAGE mode (`deltaMode !== 0`) is never trackpad — always mouse (I4).
  * See `docs/system/wheel-intent.md` for rationale.
  *
- * Pass `{ inputDevice: "trackpad" | "mouse" }` when the app knows the primary wheel device
- * and Mac Chrome/YaBrowser heuristics are ambiguous.
+ * Pass `wheelInputDevice` at resolve time (camera constant `WHEEL_INPUT_DEVICE`) when the app
+ * knows the primary wheel device and Mac Chrome/YaBrowser heuristics are ambiguous.
  */
-export function createWheelIntentResolver(options: TCreateWheelIntentResolverOptions = {}): TResolveWheelIntent {
-  const inputDevice = options.inputDevice ?? "auto";
+export function createWheelIntentResolver(): TResolveWheelIntent {
   let lastIntent: EWheelIntent = EWheelIntent.Zoom;
   let lastRule: TWheelIntentRule = WHEEL_INTENT_RULE.I5_LAST_INTENT;
   let lastTimestamp: number | null = null;
@@ -593,7 +592,9 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
     };
   };
 
-  return (event: WheelEvent, mouseWheelBehavior: TMouseWheelBehavior): EWheelIntent => {
+  return (event: WheelEvent, options: TResolveWheelIntentOptions): EWheelIntent => {
+    const mouseWheelBehavior = options.mouseWheelBehavior;
+    const wheelInputDevice = options.wheelInputDevice ?? "auto";
     const now = performance.now();
     const timeSince = lastTimestamp !== null ? now - lastTimestamp : Number.POSITIVE_INFINITY;
     lastTimestamp = now;
@@ -616,10 +617,10 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
     } else if (signals.isDiagonalScroll || signals.isPredominantHorizontalScroll) {
       intent = EWheelIntent.Pan;
       rule = WHEEL_INTENT_RULE.I2_HORIZONTAL_OR_DIAGONAL;
-    } else if (inputDevice === "trackpad") {
+    } else if (wheelInputDevice === "trackpad") {
       intent = EWheelIntent.Pan;
       rule = WHEEL_INTENT_RULE.I3_INPUT_DEVICE_TRACKPAD;
-    } else if (inputDevice === "mouse") {
+    } else if (wheelInputDevice === "mouse") {
       ({ intent, rule } = resolveExplicitMouseIntent(
         ctx,
         signals,
@@ -672,7 +673,7 @@ export function createWheelIntentResolver(options: TCreateWheelIntentResolverOpt
       emitDebugEntry(
         ctx,
         mouseWheelBehavior,
-        inputDevice,
+        wheelInputDevice,
         timeSince,
         isRapidStream,
         inMouseWheelBurst,


### PR DESCRIPTION
## Summary
- Fix fast trackpad swipes on Mac Chrome/YaBrowser being misclassified as zoom instead of pan
- Exclude `wheelDelta ≈ 3×deltaY` (Mac Chrome trackpad pattern) from `hasLegacyMouseWheelDelta` detection
- Add regression test reproducing YaBrowser trackpad swipe log

## Test plan
- [x] `npm test -- wheelIntent.test.ts` (28 tests pass)
- [ ] Verify fast trackpad swipe pans the graph in YaBrowser/Chrome on macOS
- [ ] Verify Windows Chromium mouse wheel still zooms with `MOUSE_WHEEL_BEHAVIOR=zoom`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Adjust wheel intent resolution to better distinguish trackpad vs mouse input, prevent mid-gesture intent flips, and expose explicit wheel input device configuration, with updated docs, stories, and tests.

New Features:
- Introduce wheelInputDevice setting and resolver option to explicitly classify wheel input as trackpad or mouse.
- Add rapid-stream sticky intent rule to keep prior pan/zoom intent within fast wheel gesture streams.
- Expose TWheelInputDevice type and wheelInputDevice setting through graph configuration and public API.

Bug Fixes:
- Exclude Mac Chrome/YaBrowser linear wheelDelta (~3×deltaY) from legacy mouse wheel detection so fast trackpad swipes stay as pan instead of zoom.

Enhancements:
- Refine wheel intent rules, priority order, and documentation to cover Mac Chrome edge cases and explicit device modes.
- Extend wheel intent debug output with inputDevice and new signals, and update stories to control wheelInputDevice alongside MOUSE_WHEEL_BEHAVIOR.

Documentation:
- Expand wheel intent and camera documentation with detailed wheelInputDevice mode explanations, decision flow, and Mac Chrome behavior guidance.

Tests:
- Add tests covering Mac Chrome trackpad wheel pattern, rapid-stream sticky intent behavior, and explicit mouse/trackpad modes in the resolver.