### PR TITLE
fix(connections): guard isPointInStroke before graph initialization

### DIFF
--- a/src/components/canvas/connections/BlockConnection.ts
+++ b/src/components/canvas/connections/BlockConnection.ts
@@ -33,7 +33,7 @@ export class BlockConnection<T extends TConnection>
 {
   public readonly cursor = "pointer";
 
-  protected path2d: Path2D;
+  protected path2d: Path2D = new Path2D();
 
   protected labelGeometry: { x: number; y: number; width: number; height: number } | undefined = undefined;
 
@@ -238,6 +238,7 @@ export class BlockConnection<T extends TConnection>
     this.geometry.x2 = this.connectionPoints[1].x;
     this.geometry.y2 = this.connectionPoints[1].y;
 
+    this.generatePath();
     this.applyShape();
   }
 

--- a/src/components/canvas/connections/bezierHelpers.test.ts
+++ b/src/components/canvas/connections/bezierHelpers.test.ts
@@ -1,0 +1,29 @@
+import { isPointInStroke } from "./bezierHelpers";
+
+describe("isPointInStroke", () => {
+  it("returns false when path is undefined", () => {
+    const ctx = document.createElement("canvas").getContext("2d");
+
+    expect(isPointInStroke(ctx, undefined, 0, 0)).toBe(false);
+  });
+
+  it("returns false when path is not a Path2D instance", () => {
+    const ctx = document.createElement("canvas").getContext("2d");
+
+    expect(isPointInStroke(ctx, {} as Path2D, 0, 0)).toBe(false);
+  });
+
+  it("returns false when context is missing", () => {
+    const path = new Path2D();
+
+    expect(isPointInStroke(null, path, 0, 0)).toBe(false);
+  });
+
+  it("does not throw when path is invalid", () => {
+    const ctx = document.createElement("canvas").getContext("2d");
+
+    expect(() => isPointInStroke(ctx, undefined, 0, 0)).not.toThrow();
+    expect(() => isPointInStroke(ctx, {} as Path2D, 0, 0)).not.toThrow();
+    expect(() => isPointInStroke(null, new Path2D(), 0, 0)).not.toThrow();
+  });
+});

--- a/src/components/canvas/connections/bezierHelpers.ts
+++ b/src/components/canvas/connections/bezierHelpers.ts
@@ -62,7 +62,7 @@ export function isPointInStroke(
   path: Path2D | undefined | null,
   x: number,
   y: number,
-  threshold?: number,
+  threshold?: number
 ): boolean {
   if (!ctx || !path || !(path instanceof Path2D)) {
     return false;

--- a/src/components/canvas/connections/bezierHelpers.ts
+++ b/src/components/canvas/connections/bezierHelpers.ts
@@ -57,7 +57,17 @@ export function getPointOfBezierCurve(
   /* eslint-enable no-restricted-properties */
 }
 
-export function isPointInStroke(ctx: CanvasRenderingContext2D, path: Path2D, x: number, y: number, threshold?: number) {
+export function isPointInStroke(
+  ctx: CanvasRenderingContext2D | undefined | null,
+  path: Path2D | undefined | null,
+  x: number,
+  y: number,
+  threshold?: number,
+): boolean {
+  if (!ctx || !path || !(path instanceof Path2D)) {
+    return false;
+  }
+
   const l = ctx.lineWidth;
   if (threshold) {
     ctx.lineWidth = threshold;


### PR DESCRIPTION
## Summary
- Fix `Uncaught TypeError: Failed to execute 'isPointInStroke' on 'CanvasRenderingContext2D': parameter 1 is not of type 'Path2D'` when moving the mouse before the graph finishes initializing
- Add defensive checks in `isPointInStroke` for missing context and invalid path
- Initialize connection `path2d` early and regenerate it on geometry updates so hit testing has a valid path before the first render

## Test plan
- [x] `npm test -- bezierHelpers.test.ts`
- [ ] Open graph in Storybook, move mouse immediately on mount — no console errors
- [ ] Verify connection hover/click still works after graph is fully loaded


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Guard canvas hit-testing against uninitialized graph state to prevent runtime errors when interacting with connections before initial render completes.

Bug Fixes:
- Prevent isPointInStroke from throwing when called with a missing canvas context or invalid Path2D, returning false instead.
- Avoid connection hover/click errors by initializing BlockConnection path2d early and regenerating it when geometry updates.

Tests:
- Add unit tests covering isPointInStroke behavior with undefined, invalid, and missing arguments to ensure it fails safely.