### PR TITLE
fix: expose anchor size CSS variables

### DIFF
--- a/docs/react/usage.md
+++ b/docs/react/usage.md
@@ -140,6 +140,8 @@ Anchor styling also uses CSS variables:
 .anchor {
   --graph-block-anchor-bg: rgba(255, 190, 92, 1);
   --graph-block-anchor-border-selected: rgba(255, 190, 92, 1);
+  --graph-block-anchor-width: 20px;
+  --graph-block-anchor-height: 20px;
 }
 ```
 

--- a/docs/react/usage.md
+++ b/docs/react/usage.md
@@ -110,6 +110,7 @@ import { GraphBlockAnchor } from "@gravity-ui/graph/react";
   graph={graph} 
   anchor={anchor}
   position="fixed"
+  className="anchor"
 >
   {(state) => (
     <div className={state.selected ? 'selected' : ''}>
@@ -125,6 +126,7 @@ import { GraphBlockAnchor } from "@gravity-ui/graph/react";
   graph={graph} 
   anchor={anchor}
   position="auto"
+  className="anchor"
   // Inputs will be placed on the left, outputs on the right
 >
   {(state) => (
@@ -437,9 +439,10 @@ function BlockComponent({ block, graph }: { block: TBlock; graph: Graph }) {
           graph={graph}
           anchor={anchor}
           position="fixed"
+          className="anchor"
         >
           {(state) => (
-            <div className={`anchor ${state.selected ? 'selected' : ''}`}>
+            <div className="anchor-content">
               <div className="anchor-dot" />
               {state.isConnecting && (
                 <div className="anchor-label">
@@ -571,15 +574,15 @@ const styles = `
 }
 
 .anchor {
+  --graph-block-anchor-width: 12px;
+  --graph-block-anchor-height: 12px;
   position: absolute;
-  width: 12px;
-  height: 12px;
   background: var(--graph-block-anchor-bg);
   border-radius: 50%;
   cursor: pointer;
 }
 
-.anchor.selected {
+.anchor.graph-block-anchor-selected {
   border: 2px solid var(--graph-block-anchor-border-selected);
 }
 

--- a/e2e/tests/anchor/anchor-css-variables.spec.ts
+++ b/e2e/tests/anchor/anchor-css-variables.spec.ts
@@ -68,4 +68,40 @@ test.describe("Anchor CSS variables", () => {
       height: "20px",
     });
   });
+
+  test("allows consumers to override sizes on the graph wrapper", async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const consumerStyle = document.createElement("style");
+      consumerStyle.textContent = `
+        .graph-wrapper.consumer-graph {
+          --graph-block-anchor-width: 24px;
+          --graph-block-anchor-height: 20px;
+        }
+      `;
+      document.head.prepend(consumerStyle);
+
+      const graph = document.createElement("div");
+      graph.className = "graph-wrapper consumer-graph";
+
+      const anchor = document.createElement("div");
+      anchor.className = "graph-block-anchor";
+      graph.appendChild(anchor);
+      document.body.appendChild(graph);
+
+      const computedStyle = window.getComputedStyle(anchor);
+      return {
+        widthVariable: computedStyle.getPropertyValue("--graph-block-anchor-width").trim(),
+        heightVariable: computedStyle.getPropertyValue("--graph-block-anchor-height").trim(),
+        width: computedStyle.width,
+        height: computedStyle.height,
+      };
+    });
+
+    expect(styles).toEqual({
+      widthVariable: "24px",
+      heightVariable: "20px",
+      width: "24px",
+      height: "20px",
+    });
+  });
 });

--- a/e2e/tests/anchor/anchor-css-variables.spec.ts
+++ b/e2e/tests/anchor/anchor-css-variables.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Anchor CSS variables", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/base.html");
+    await page.waitForFunction(() => (window as Window & { graphLibraryLoaded?: boolean }).graphLibraryLoaded === true);
+  });
+
+  test("provides default width and height values", async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const graph = document.createElement("div");
+      graph.className = "graph-wrapper";
+
+      const anchor = document.createElement("div");
+      anchor.className = "graph-block-anchor";
+      graph.appendChild(anchor);
+      document.body.appendChild(graph);
+
+      const computedStyle = window.getComputedStyle(anchor);
+      return {
+        widthVariable: computedStyle.getPropertyValue("--graph-block-anchor-width").trim(),
+        heightVariable: computedStyle.getPropertyValue("--graph-block-anchor-height").trim(),
+        width: computedStyle.width,
+        height: computedStyle.height,
+      };
+    });
+
+    expect(styles).toEqual({
+      widthVariable: "16px",
+      heightVariable: "16px",
+      width: "16px",
+      height: "16px",
+    });
+  });
+
+  test("allows consumers to override width and height", async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const graph = document.createElement("div");
+      graph.className = "graph-wrapper";
+      graph.style.setProperty("--graph-block-anchor-width", "24px");
+      graph.style.setProperty("--graph-block-anchor-height", "20px");
+
+      const anchor = document.createElement("div");
+      anchor.className = "graph-block-anchor";
+      graph.appendChild(anchor);
+      document.body.appendChild(graph);
+
+      const computedStyle = window.getComputedStyle(anchor);
+      return {
+        widthVariable: computedStyle.getPropertyValue("--graph-block-anchor-width").trim(),
+        heightVariable: computedStyle.getPropertyValue("--graph-block-anchor-height").trim(),
+        width: computedStyle.width,
+        height: computedStyle.height,
+      };
+    });
+
+    expect(styles).toEqual({
+      widthVariable: "24px",
+      heightVariable: "20px",
+      width: "24px",
+      height: "20px",
+    });
+  });
+});

--- a/e2e/tests/anchor/anchor-css-variables.spec.ts
+++ b/e2e/tests/anchor/anchor-css-variables.spec.ts
@@ -34,14 +34,21 @@ test.describe("Anchor CSS variables", () => {
   });
 
   test("allows consumers to override width and height", async ({ page }) => {
+    await page.addStyleTag({
+      content: `
+        .anchor {
+          --graph-block-anchor-width: 24px;
+          --graph-block-anchor-height: 20px;
+        }
+      `,
+    });
+
     const styles = await page.evaluate(() => {
       const graph = document.createElement("div");
       graph.className = "graph-wrapper";
-      graph.style.setProperty("--graph-block-anchor-width", "24px");
-      graph.style.setProperty("--graph-block-anchor-height", "20px");
 
       const anchor = document.createElement("div");
-      anchor.className = "graph-block-anchor";
+      anchor.className = "graph-block-anchor anchor";
       graph.appendChild(anchor);
       document.body.appendChild(graph);
 

--- a/src/react-components/Anchor.css
+++ b/src/react-components/Anchor.css
@@ -1,12 +1,12 @@
 .graph-block-anchor {
-  --width: var(--graph-block-anchor-width);
-  --height: var(--graph-block-anchor-height);
+  --width: var(--graph-block-anchor-width, 16px);
+  --height: var(--graph-block-anchor-height, 16px);
   display: inline-block;
   box-sizing: border-box;
   border-radius: 50%;
   background-color: var(--graph-block-anchor-bg);
-  width: var(--graph-block-anchor-width);
-  height: var(--graph-block-anchor-height);
+  width: var(--width);
+  height: var(--height);
   cursor: pointer;
 }
 

--- a/src/react-components/Anchor.css
+++ b/src/react-components/Anchor.css
@@ -1,12 +1,12 @@
 .graph-block-anchor {
-  --width: var(--graph-block-anchor-width, 16px);
-  --height: var(--graph-block-anchor-height, 16px);
+  --width: var(--graph-block-anchor-width);
+  --height: var(--graph-block-anchor-height);
   display: inline-block;
   box-sizing: border-box;
   border-radius: 50%;
   background-color: var(--graph-block-anchor-bg);
-  width: var(--graph-block-anchor-width, 16px);
-  height: var(--graph-block-anchor-height, 16px);
+  width: var(--graph-block-anchor-width);
+  height: var(--graph-block-anchor-height);
   cursor: pointer;
 }
 

--- a/src/react-components/graph-canvas.css
+++ b/src/react-components/graph-canvas.css
@@ -1,4 +1,6 @@
 .graph-wrapper {
+    --graph-block-anchor-width: 16px;
+    --graph-block-anchor-height: 16px;
     position: relative;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
## Summary

- provide default `--graph-block-anchor-width` and `--graph-block-anchor-height` values on the graph wrapper
- consume the size variables without fallback declarations while preserving CSS overrides
- document anchor sizing and add browser regression coverage for defaults and overrides

## Root cause

Anchor coordinates were exposed as concrete CSS custom-property values, while width and height existed only as fallbacks inside `var(...)`. As a result, consumers could not read default values from the custom properties and CSS processing could emit duplicate width and height declarations.

## Impact

The rendered anchor size remains `16px × 16px` by default. Consumers can continue overriding either dimension through the CSS cascade; no inline values are introduced.

## Validation

- `CI=1 npx playwright test e2e/tests/anchor/anchor-css-variables.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`
- `git diff --check`

Fixes #329

## Summary by Sourcery

Expose default graph anchor dimensions through CSS variables and verify that consumers can override them.

Bug Fixes:
- Expose default anchor width and height as readable CSS custom properties while retaining cascade-based consumer overrides.

Enhancements:
- Document configurable anchor sizing through CSS variables.

Documentation:
- Add anchor size variables to the React usage and styling documentation.

Tests:
- Add browser regression coverage for default anchor dimensions and overrides on anchors and graph wrappers.